### PR TITLE
feat: add notification dispatcher and audit logging

### DIFF
--- a/backend/src/audit.ts
+++ b/backend/src/audit.ts
@@ -1,0 +1,63 @@
+export interface AuditEvent {
+  entity: string;
+  action: 'create' | 'update';
+  actor: string;
+  entityId: string;
+  timestamp: Date;
+  changes?: Record<string, { before: any; after: any }>;
+}
+
+const auditLog: AuditEvent[] = [];
+
+export function logCreate(
+  entity: string,
+  entityId: string,
+  actor: string,
+  data: Record<string, any>
+): AuditEvent {
+  const changes: Record<string, { before: any; after: any }> = {};
+  for (const [key, value] of Object.entries(data)) {
+    changes[key] = { before: undefined, after: value };
+  }
+  const event: AuditEvent = {
+    entity,
+    entityId,
+    actor,
+    action: 'create',
+    timestamp: new Date(),
+    changes,
+  };
+  auditLog.push(event);
+  console.log(`AUDIT create ${entity} ${entityId}`);
+  return event;
+}
+
+export function logUpdate(
+  entity: string,
+  entityId: string,
+  actor: string,
+  before: Record<string, any>,
+  after: Record<string, any>
+): AuditEvent {
+  const changes: Record<string, { before: any; after: any }> = {};
+  for (const key of Object.keys(after)) {
+    if (before[key] !== after[key]) {
+      changes[key] = { before: before[key], after: after[key] };
+    }
+  }
+  const event: AuditEvent = {
+    entity,
+    entityId,
+    actor,
+    action: 'update',
+    timestamp: new Date(),
+    changes,
+  };
+  auditLog.push(event);
+  console.log(`AUDIT update ${entity} ${entityId}`);
+  return event;
+}
+
+export function getAuditLog(): AuditEvent[] {
+  return auditLog;
+}

--- a/backend/src/notifications/dispatcher.ts
+++ b/backend/src/notifications/dispatcher.ts
@@ -1,0 +1,23 @@
+export interface NotificationEvent {
+  type: string;
+  recipient: string;
+  subject: string;
+  body: string;
+  timestamp: Date;
+}
+
+const events: NotificationEvent[] = [];
+
+export async function dispatch(event: NotificationEvent): Promise<void> {
+  events.push(event);
+  await sendEmail(event);
+}
+
+async function sendEmail(event: NotificationEvent): Promise<void> {
+  // Email send stub
+  console.log(`Email to ${event.recipient}: ${event.subject}`);
+}
+
+export function getDispatchedEvents(): NotificationEvent[] {
+  return events;
+}

--- a/backend/src/workflows/engine.ts
+++ b/backend/src/workflows/engine.ts
@@ -1,0 +1,32 @@
+import { dispatch, NotificationEvent } from '../notifications/dispatcher';
+import { logCreate, logUpdate } from '../audit';
+
+export interface SideEffect {
+  type: 'notification';
+  notification: Omit<NotificationEvent, 'timestamp'>;
+}
+
+export interface WorkflowContext {
+  actor: string;
+  entity: string;
+  entityId: string;
+  before?: Record<string, any>;
+  after: Record<string, any>;
+}
+
+export async function runWorkflow(
+  sideEffects: SideEffect[],
+  ctx: WorkflowContext
+): Promise<void> {
+  for (const effect of sideEffects) {
+    if (effect.type === 'notification') {
+      await dispatch({ ...effect.notification, timestamp: new Date() });
+    }
+  }
+
+  if (ctx.before) {
+    logUpdate(ctx.entity, ctx.entityId, ctx.actor, ctx.before, ctx.after);
+  } else {
+    logCreate(ctx.entity, ctx.entityId, ctx.actor, ctx.after);
+  }
+}


### PR DESCRIPTION
## Summary
- add notification dispatcher with email stub
- provide audit helpers to log create/update events
- run workflow side effects to dispatch notifications and record audits

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab814abb3c8325b1a52a507a1f1cff