### PR TITLE
feat: add account routes

### DIFF
--- a/backend/src/routes/accounts.ts
+++ b/backend/src/routes/accounts.ts
@@ -1,0 +1,33 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { prisma } from '../db';
+import { HttpError } from '../middleware/errorHandler';
+
+const router = Router();
+
+// Create a new account
+router.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  const { name } = req.body || {};
+  if (!name) {
+    return next(new HttpError(400, 'name required'));
+  }
+  try {
+    const account = await prisma.account.create({
+      data: { name },
+    });
+    return res.json(account);
+  } catch (err) {
+    return next(new HttpError(500, 'Failed to create account'));
+  }
+});
+
+// List all accounts
+router.get('/', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const accounts = await prisma.account.findMany();
+    return res.json(accounts);
+  } catch (err) {
+    return next(new HttpError(500, 'Failed to fetch accounts'));
+  }
+});
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import authLogin from './authLogin';
 import authLogout from './authLogout';
+import accounts from './accounts';
 import projects from './projects';
 import projectOwner from './projectOwner';
 import projectContacts from './projectContacts';
@@ -17,6 +18,7 @@ const router = Router();
 
 router.use('/auth/login', authLogin);
 router.use('/auth/logout', authLogout);
+router.use('/accounts', accounts);
 router.use('/projects', projects);
 router.use('/projects/:project_id/owner', projectOwner);
 router.use('/projects/:project_id/contacts', projectContacts);


### PR DESCRIPTION
## Summary
- add routes for creating and listing accounts
- wire accounts routes into central router

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8889b4748325be9c40afea444ae7