### PR TITLE
feat: prompt for refresh on service worker update

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,5 @@
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -14,5 +14,45 @@ createRoot(document.getElementById('root')).render(
         <App />
       </BrowserRouter>
     </QueryClientProvider>
-  </StrictMode>
+  </StrictMode>,
 );
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/sw.js')
+      .then((registration) => {
+        const promptUserToRefresh = () => {
+          if (window.confirm('New version available. Refresh now?')) {
+            registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+            navigator.serviceWorker.addEventListener(
+              'controllerchange',
+              () => window.location.reload(),
+              { once: true },
+            );
+          }
+        };
+
+        if (registration.waiting) {
+          promptUserToRefresh();
+        }
+
+        registration.addEventListener('updatefound', () => {
+          const newWorker = registration.installing;
+          if (newWorker) {
+            newWorker.addEventListener('statechange', () => {
+              if (
+                newWorker.state === 'installed' &&
+                registration.waiting
+              ) {
+                promptUserToRefresh();
+              }
+            });
+          }
+        });
+      })
+      .catch((error) => {
+        console.error('Service worker registration failed:', error);
+      });
+  });
+}


### PR DESCRIPTION
## Summary
- register service worker and prompt user to refresh when new version is waiting
- add service worker handler for `SKIP_WAITING` messages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab8e6154748325aabc8639197a42e5