### PR TITLE
feat: cache API responses and queue offline requests

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,146 @@
+/* eslint-env serviceworker */
+const API_CACHE = 'api-cache-v1';
+const DB_NAME = 'request-queue';
+const STORE_NAME = 'requests';
+
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    await self.clients.claim();
+    await broadcastQueueLength();
+    await flushQueue();
+  })());
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (request.method === 'GET' && url.pathname.startsWith('/api/')) {
+    event.respondWith((async () => {
+      const cache = await caches.open(API_CACHE);
+      const cached = await cache.match(request);
+      const fetchPromise = fetch(request).then((networkResponse) => {
+        cache.put(request, networkResponse.clone());
+        return networkResponse;
+      });
+      if (cached) {
+        event.waitUntil(fetchPromise.catch(() => {}));
+        return cached;
+      }
+      return fetchPromise;
+    })());
+    return;
+  }
+
+  if ((request.method === 'POST' || request.method === 'PUT') && url.pathname.startsWith('/api/')) {
+    event.respondWith((async () => {
+      try {
+        return await fetch(request.clone());
+      } catch (err) {
+        console.error('Queuing request due to offline mode', err);
+        await enqueueRequest(request.clone());
+        await broadcastQueueLength();
+        return new Response(JSON.stringify({ queued: true }), {
+          status: 202,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    })());
+  }
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'FLUSH_QUEUE') {
+    event.waitUntil(flushQueue());
+  }
+});
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = (event) => {
+      event.target.result.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function enqueueRequest(request) {
+  const db = await openDB();
+  const body = await request.text();
+  const headers = {};
+  request.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).add({
+      method: request.method,
+      url: request.url,
+      headers,
+      body,
+      createdAt: Date.now(),
+    });
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function getAllRequests() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.getAll();
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function deleteRequest(id) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function flushQueue() {
+  const requests = await getAllRequests();
+    for (const item of requests) {
+      try {
+        await fetch(item.url, {
+          method: item.method,
+          headers: item.headers,
+          body: item.body,
+        });
+        await deleteRequest(item.id);
+      } catch (err) {
+        console.error('Failed to replay request', err);
+        // keep request for retry
+      }
+    }
+  await broadcastQueueLength();
+}
+
+async function getQueueLength() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.count();
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function broadcastQueueLength() {
+  const length = await getQueueLength();
+  const clientList = await self.clients.matchAll();
+  clientList.forEach((client) => client.postMessage({ type: 'QUEUE_LENGTH', length }));
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,14 +2,18 @@ import { Routes, Route } from 'react-router-dom';
 import Login from '@/pages/Login';
 import ProjectList from '@/pages/ProjectList';
 import ProjectDashboard from '@/pages/ProjectDashboard';
+import Header from '@/components/Header';
 
 function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Login />} />
-      <Route path="/projects" element={<ProjectList />} />
-      <Route path="/projects/:projectId" element={<ProjectDashboard />} />
-    </Routes>
+    <>
+      <Header />
+      <Routes>
+        <Route path="/" element={<Login />} />
+        <Route path="/projects" element={<ProjectList />} />
+        <Route path="/projects/:projectId" element={<ProjectDashboard />} />
+      </Routes>
+    </>
   );
 }
 

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+export default function Header() {
+  const [online, setOnline] = useState(navigator.onLine);
+  const [queueLength, setQueueLength] = useState(0);
+
+  useEffect(() => {
+    const updateOnline = () => setOnline(navigator.onLine);
+    window.addEventListener('online', updateOnline);
+    window.addEventListener('offline', updateOnline);
+
+    const handleMessage = (event) => {
+      if (event.data?.type === 'QUEUE_LENGTH') {
+        setQueueLength(event.data.length);
+      }
+    };
+    navigator.serviceWorker?.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('online', updateOnline);
+      window.removeEventListener('offline', updateOnline);
+      navigator.serviceWorker?.removeEventListener('message', handleMessage);
+    };
+  }, []);
+
+  return (
+    <header className="p-2 bg-gray-100 flex justify-between text-sm">
+      <span className="font-bold">Crewdex</span>
+      <span>
+        {online ? 'Online' : 'Offline'}
+        {queueLength > 0 && ` • Queue: ${queueLength}`}
+      </span>
+    </header>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -16,3 +16,14 @@ createRoot(document.getElementById('root')).render(
     </QueryClientProvider>
   </StrictMode>
 );
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+  window.addEventListener('online', () => {
+    navigator.serviceWorker.ready.then((reg) => {
+      reg.active?.postMessage({ type: 'FLUSH_QUEUE' });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add service worker to cache API GET responses with stale-while-revalidate
- queue offline POST/PUT API calls in IndexedDB and replay when back online
- show network and queue status in a new header component

## Testing
- `npm test --workspace frontend`
- `npm run lint --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68ab8e532b988325aaaf5075a787d161