### PR TITLE
feat: add responsive layout and list components

### DIFF
--- a/frontend/src/components/ResponsiveLayout.jsx
+++ b/frontend/src/components/ResponsiveLayout.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function ResponsiveLayout({ sidebar, children }) {
+  return (
+    <div className="grid min-h-screen grid-cols-1 md:grid-cols-1 lg:grid-cols-[250px_1fr]">
+      {sidebar && (
+        <aside className="border-b p-4 lg:border-b-0 lg:border-r">
+          {sidebar}
+        </aside>
+      )}
+      <main className="p-4">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/components/ResponsiveList.jsx
+++ b/frontend/src/components/ResponsiveList.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export default function ResponsiveList({ items, columns }) {
+  return (
+    <>
+      <table className="hidden w-full text-left md:table">
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th key={col.key} className="border-b p-2">
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.id} className="border-b last:border-0">
+              {columns.map((col) => (
+                <td key={col.key} className="p-2">
+                  {col.render ? col.render(item) : item[col.key]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="space-y-4 md:hidden">
+        {items.map((item) => (
+          <div key={item.id} className="rounded border p-4">
+            {columns.map((col) => (
+              <div key={col.key} className="flex justify-between">
+                <span className="font-medium">{col.header}</span>
+                <span>{col.render ? col.render(item) : item[col.key]}</span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,22 +1,25 @@
 import { Button } from '@/components/ui/button';
+import ResponsiveLayout from '@/components/ResponsiveLayout';
 
 export default function Login() {
   return (
-    <div className="flex min-h-screen items-center justify-center p-4">
-      <div className="w-full max-w-sm space-y-4">
-        <h1 className="text-center text-2xl font-bold">Login</h1>
-        <input
-          type="email"
-          placeholder="Email"
-          className="w-full rounded border p-2"
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          className="w-full rounded border p-2"
-        />
-        <Button className="w-full">Sign In</Button>
+    <ResponsiveLayout>
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="w-full max-w-sm space-y-4">
+          <h1 className="text-center text-2xl font-bold">Login</h1>
+          <input
+            type="email"
+            placeholder="Email"
+            className="w-full rounded border p-2"
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            className="w-full rounded border p-2"
+          />
+          <Button className="w-full">Sign In</Button>
+        </div>
       </div>
-    </div>
+    </ResponsiveLayout>
   );
 }

--- a/frontend/src/pages/ProjectDashboard.jsx
+++ b/frontend/src/pages/ProjectDashboard.jsx
@@ -1,8 +1,12 @@
+import ResponsiveLayout from '@/components/ResponsiveLayout';
+
 export default function ProjectDashboard() {
   return (
-    <div className="p-4">
+    <ResponsiveLayout sidebar={<div>Sidebar</div>}>
       <h1 className="text-xl font-bold">Project Dashboard</h1>
-      <p className="mt-2 text-sm text-muted-foreground">Project details will appear here.</p>
-    </div>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Project details will appear here.
+      </p>
+    </ResponsiveLayout>
   );
 }

--- a/frontend/src/pages/ProjectList.jsx
+++ b/frontend/src/pages/ProjectList.jsx
@@ -1,17 +1,20 @@
 import { Link } from 'react-router-dom';
+import ResponsiveLayout from '@/components/ResponsiveLayout';
+import ResponsiveList from '@/components/ResponsiveList';
 
 export default function ProjectList() {
   const projects = [{ id: '1', name: 'Demo Project' }];
+  const columns = [
+    {
+      key: 'name',
+      header: 'Name',
+      render: (p) => <Link to={`/projects/${p.id}`}>{p.name}</Link>,
+    },
+  ];
   return (
-    <div className="p-4">
+    <ResponsiveLayout sidebar={<div>Sidebar</div>}>
       <h1 className="mb-4 text-xl font-bold">Projects</h1>
-      <ul className="space-y-2">
-        {projects.map((p) => (
-          <li key={p.id} className="rounded border p-2 hover:bg-accent">
-            <Link to={`/projects/${p.id}`}>{p.name}</Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+      <ResponsiveList items={projects} columns={columns} />
+    </ResponsiveLayout>
   );
 }


### PR DESCRIPTION
## Summary
- implement responsive layout with Tailwind breakpoints for two-column vs single-column views
- introduce ResponsiveList to render tables on desktop and cards on mobile
- update pages to use shared layout and new list component

## Testing
- `npm test --workspace frontend`
- `npm run lint --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68ab8e5984d8832583fd883e2165d358