### PR TITLE
Improve accessibility and motion preferences

### DIFF
--- a/frontend/src/components/ContactDetail.jsx
+++ b/frontend/src/components/ContactDetail.jsx
@@ -6,8 +6,14 @@ export function ContactDetail({ open, onOpenChange }) {
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/50" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded bg-background p-4 shadow">
-          <Dialog.Title className="mb-2 text-lg font-bold">Contact Detail</Dialog.Title>
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded bg-background p-4 shadow"
+          aria-labelledby="contact-detail-title"
+          aria-modal="true"
+        >
+          <Dialog.Title id="contact-detail-title" className="mb-2 text-lg font-bold">
+            Contact Detail
+          </Dialog.Title>
           <div className="space-y-2">
             <p className="text-sm text-muted-foreground">Contact info...</p>
           </div>
@@ -19,3 +25,4 @@ export function ContactDetail({ open, onOpenChange }) {
     </Dialog.Root>
   );
 }
+

--- a/frontend/src/components/FlagModal.jsx
+++ b/frontend/src/components/FlagModal.jsx
@@ -6,8 +6,14 @@ export function FlagModal({ open, onOpenChange }) {
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/50" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded bg-background p-4 shadow">
-          <Dialog.Title className="mb-2 text-lg font-bold">Flag</Dialog.Title>
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded bg-background p-4 shadow"
+          aria-labelledby="flag-modal-title"
+          aria-modal="true"
+        >
+          <Dialog.Title id="flag-modal-title" className="mb-2 text-lg font-bold">
+            Flag
+          </Dialog.Title>
           <div className="space-y-2">
             <p className="text-sm text-muted-foreground">Flag details...</p>
           </div>
@@ -19,3 +25,4 @@ export function FlagModal({ open, onOpenChange }) {
     </Dialog.Root>
   );
 }
+

--- a/frontend/src/components/ProjectSettingsModal.jsx
+++ b/frontend/src/components/ProjectSettingsModal.jsx
@@ -6,8 +6,14 @@ export function ProjectSettingsModal({ open, onOpenChange }) {
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/50" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded bg-background p-4 shadow">
-          <Dialog.Title className="mb-2 text-lg font-bold">Project Settings</Dialog.Title>
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded bg-background p-4 shadow"
+          aria-labelledby="project-settings-title"
+          aria-modal="true"
+        >
+          <Dialog.Title id="project-settings-title" className="mb-2 text-lg font-bold">
+            Project Settings
+          </Dialog.Title>
           <div className="space-y-2">
             <p className="text-sm text-muted-foreground">Settings content...</p>
           </div>
@@ -19,3 +25,4 @@ export function ProjectSettingsModal({ open, onOpenChange }) {
     </Dialog.Root>
   );
 }
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,4 +6,15 @@
   body {
     @apply min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-50;
   }
+  :focus-visible {
+    @apply outline-none ring-2 ring-offset-2 ring-blue-500;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    * {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -5,15 +5,21 @@ export default function Login() {
     <div className="flex min-h-screen items-center justify-center p-4">
       <div className="w-full max-w-sm space-y-4">
         <h1 className="text-center text-2xl font-bold">Login</h1>
+        <label htmlFor="email" className="block text-sm font-medium">
+          Email
+        </label>
         <input
+          id="email"
           type="email"
-          placeholder="Email"
-          className="w-full rounded border p-2"
+          className="w-full rounded border p-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
         />
+        <label htmlFor="password" className="block text-sm font-medium">
+          Password
+        </label>
         <input
+          id="password"
           type="password"
-          placeholder="Password"
-          className="w-full rounded border p-2"
+          className="w-full rounded border p-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
         />
         <Button className="w-full">Sign In</Button>
       </div>

--- a/frontend/src/pages/ProjectList.jsx
+++ b/frontend/src/pages/ProjectList.jsx
@@ -7,8 +7,14 @@ export default function ProjectList() {
       <h1 className="mb-4 text-xl font-bold">Projects</h1>
       <ul className="space-y-2">
         {projects.map((p) => (
-          <li key={p.id} className="rounded border p-2 hover:bg-accent">
-            <Link to={`/projects/${p.id}`}>{p.name}</Link>
+          <li key={p.id}>
+            <Link
+              to={`/projects/${p.id}`}
+              className="block rounded border p-2 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+              aria-label={`Open project ${p.name}`}
+            >
+              {p.name}
+            </Link>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add labels and keyboard focus rings to login form inputs
- enhance project list links with visible focus states and aria labels
- add global focus styles and reduced-motion support
- ensure modal dialogs have correct background color and ARIA attributes

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab8ea441e08325b76adfb63ab2aaa4