### PR TITLE
feat: add jwt auth middleware

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "@prisma/client": "^6.14.0",
         "express": "^4.18.2",
+        "jsonwebtoken": "^9.0.2",
         "prisma": "^6.14.0"
       },
       "devDependencies": {
-        "@types/express": "^4.17.21"
+        "@types/express": "^4.17.21",
+        "@types/jsonwebtoken": "^9.0.6"
       }
     },
     "node_modules/@prisma/client": {
@@ -156,10 +158,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -252,6 +272,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -467,6 +493,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -809,6 +844,97 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1127,6 +1253,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,9 +18,11 @@
   "dependencies": {
     "@prisma/client": "^6.14.0",
     "express": "^4.18.2",
-    "prisma": "^6.14.0"
+    "prisma": "^6.14.0",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
-    "@types/express": "^4.17.21"
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.6"
   }
 }

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthUser {
+  account_id: string;
+  role: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+  user?: AuthUser;
+}
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+export const authMiddleware = (allowedRoles: string[] = []) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const header = req.headers['authorization'];
+    if (!header || !header.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const token = header.slice(7);
+    try {
+      const payload = jwt.verify(token, JWT_SECRET) as AuthUser;
+      (req as AuthenticatedRequest).user = {
+        account_id: payload.account_id,
+        role: payload.role,
+      };
+      if (allowedRoles.length && !allowedRoles.includes(payload.role)) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+      return next();
+    } catch (err) {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+  };
+};

--- a/backend/src/middleware/permissions.ts
+++ b/backend/src/middleware/permissions.ts
@@ -1,0 +1,16 @@
+export const routePermissions: Record<string, string[]> = {
+  '/auth/logout': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin', 'Viewer'],
+  '/accounts': ['AccountAdmin'],
+  '/projects': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin', 'Viewer'],
+  '/projects/:project_id/owner': ['AccountAdmin', 'ProjectOwner'],
+  '/projects/:project_id/contacts': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin'],
+  '/projects/:project_id/contacts/:project_contact_id/scopes': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin'],
+  '/projects/:project_id/flags': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin'],
+  '/projects/:project_id/photos': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin'],
+  '/projects/:project_id/flags/:flag_id/photos': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin'],
+  '/projects/:project_id/report-templates': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin'],
+  '/projects/:project_id/report-templates/:template_id/generate': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin', 'Viewer'],
+  '/projects/:project_id/schedule': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin'],
+  '/projects/:project_id/subscriptions': ['AccountAdmin', 'ProjectOwner', 'ProjectAdmin'],
+  '/billing': ['AccountAdmin']
+};

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -14,23 +14,65 @@ import reportTemplateGenerate from './reportTemplateGenerate';
 import projectSchedule from './projectSchedule';
 import projectSubscriptions from './projectSubscriptions';
 import billing from './billing';
+import { authMiddleware } from '../middleware/auth';
+import { routePermissions } from '../middleware/permissions';
 
 const router = Router();
 
 router.use('/auth/login', authLogin);
-router.use('/auth/logout', authLogout);
-router.use('/accounts', accounts);
-router.use('/projects', projects);
-router.use('/projects/:project_id/owner', projectOwner);
-router.use('/projects/:project_id/contacts', projectContacts);
-router.use('/projects/:project_id/contacts/:project_contact_id/scopes', contactScopes);
-router.use('/projects/:project_id/flags', projectFlags);
-router.use('/projects/:project_id/photos', projectPhotos);
-router.use('/projects/:project_id/flags/:flag_id/photos', flagPhotos);
-router.use('/projects/:project_id/report-templates', reportTemplates);
-router.use('/projects/:project_id/report-templates/:template_id/generate', reportTemplateGenerate);
-router.use('/projects/:project_id/schedule', projectSchedule);
-router.use('/projects/:project_id/subscriptions', projectSubscriptions);
-router.use('/billing', billing);
+router.use('/auth/logout', authMiddleware(routePermissions['/auth/logout']), authLogout);
+router.use('/accounts', authMiddleware(routePermissions['/accounts']), accounts);
+router.use('/projects', authMiddleware(routePermissions['/projects']), projects);
+router.use(
+  '/projects/:project_id/owner',
+  authMiddleware(routePermissions['/projects/:project_id/owner']),
+  projectOwner
+);
+router.use(
+  '/projects/:project_id/contacts',
+  authMiddleware(routePermissions['/projects/:project_id/contacts']),
+  projectContacts
+);
+router.use(
+  '/projects/:project_id/contacts/:project_contact_id/scopes',
+  authMiddleware(routePermissions['/projects/:project_id/contacts/:project_contact_id/scopes']),
+  contactScopes
+);
+router.use(
+  '/projects/:project_id/flags',
+  authMiddleware(routePermissions['/projects/:project_id/flags']),
+  projectFlags
+);
+router.use(
+  '/projects/:project_id/photos',
+  authMiddleware(routePermissions['/projects/:project_id/photos']),
+  projectPhotos
+);
+router.use(
+  '/projects/:project_id/flags/:flag_id/photos',
+  authMiddleware(routePermissions['/projects/:project_id/flags/:flag_id/photos']),
+  flagPhotos
+);
+router.use(
+  '/projects/:project_id/report-templates',
+  authMiddleware(routePermissions['/projects/:project_id/report-templates']),
+  reportTemplates
+);
+router.use(
+  '/projects/:project_id/report-templates/:template_id/generate',
+  authMiddleware(routePermissions['/projects/:project_id/report-templates/:template_id/generate']),
+  reportTemplateGenerate
+);
+router.use(
+  '/projects/:project_id/schedule',
+  authMiddleware(routePermissions['/projects/:project_id/schedule']),
+  projectSchedule
+);
+router.use(
+  '/projects/:project_id/subscriptions',
+  authMiddleware(routePermissions['/projects/:project_id/subscriptions']),
+  projectSubscriptions
+);
+router.use('/billing', authMiddleware(routePermissions['/billing']), billing);
 
 export default router;


### PR DESCRIPTION
## Summary
- add jsonwebtoken dependency and types
- introduce auth middleware verifying JWTs and populating req.user
- map route-level permissions and guard routes with role checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8e4d331c8325bbeb58ee00eb7e6b