### PR TITLE
Configure PWA manifest and assets

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,14 +1,20 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
+import { readFileSync } from 'node:fs';
 import { VitePWA } from 'vite-plugin-pwa';
+
+const manifest = JSON.parse(
+  readFileSync(new URL('./public/manifest.webmanifest', import.meta.url), 'utf-8'),
+);
 
 export default defineConfig({
   plugins: [
     react(),
     VitePWA({
       registerType: 'autoUpdate',
-      manifest: false,
+      includeAssets: ['vite.svg'],
+      manifest,
       workbox: {
         runtimeCaching: [
           {


### PR DESCRIPTION
## Summary
- load existing `public/manifest.webmanifest` and feed it to VitePWA plugin
- include SVG icon in PWA build assets so install prompt works

## Testing
- `npm run build --workspace frontend`

------
https://chatgpt.com/codex/tasks/task_e_68ab956560448325a7b265c2989b7925