### PR TITLE
feat: add login form submission

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,24 +1,60 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import ResponsiveLayout from '@/components/ResponsiveLayout';
 
 export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        throw new Error('Login failed');
+      }
+      const data = await res.json();
+      const token = data?.session?.token;
+      if (token) {
+        localStorage.setItem('token', token);
+        navigate('/projects');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <ResponsiveLayout>
       <div className="flex min-h-screen items-center justify-center">
-        <div className="w-full max-w-sm space-y-4">
+        <form className="w-full max-w-sm space-y-4" onSubmit={handleSubmit}>
           <h1 className="text-center text-2xl font-bold">Login</h1>
           <input
             type="email"
             placeholder="Email"
             className="w-full rounded border p-2"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
           />
           <input
             type="password"
             placeholder="Password"
             className="w-full rounded border p-2"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
           />
-          <Button className="w-full">Sign In</Button>
-        </div>
+          <Button className="w-full" type="submit">
+            Sign In
+          </Button>
+        </form>
       </div>
     </ResponsiveLayout>
   );


### PR DESCRIPTION
## Summary
- convert login inputs to controlled components
- submit credentials to backend login endpoint
- store JWT and navigate to project list on success

## Testing
- `npm test --workspace frontend`
- `npm run lint --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68ab955a7be8832590c7f45ef72eb9fb