### PR TITLE
feat: enable md two-column layout

### DIFF
--- a/frontend/src/components/ResponsiveLayout.jsx
+++ b/frontend/src/components/ResponsiveLayout.jsx
@@ -4,9 +4,9 @@ import { useOfflineQueue } from '@/lib/offlineQueue';
 export default function ResponsiveLayout({ sidebar, children }) {
   const { online, queued } = useOfflineQueue();
   return (
-    <div className="grid min-h-screen grid-cols-1 md:grid-cols-1 lg:grid-cols-[250px_1fr]">
+    <div className="grid min-h-screen grid-cols-1 md:grid-cols-[250px_1fr]">
       {sidebar && (
-        <aside className="border-b p-4 lg:border-b-0 lg:border-r">
+        <aside className="border-b p-4 md:border-b-0 md:border-r">
           {sidebar}
         </aside>
       )}


### PR DESCRIPTION
## Summary
- allow two-column responsive layout starting at md breakpoint
- adjust sidebar borders for md breakpoint

## Testing
- `npm test --workspace frontend`
- `npm run lint --workspace frontend`
- `npm run build --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68aba03fdda08325ad694f764a48ef6a