### PR TITLE
feat: add payload validation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,11 +21,12 @@
     "cookie-parser": "^1.4.7",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
-    "prisma": "^6.14.0"
+    "prisma": "^6.14.0",
+    "zod": "^4.1.1"
   },
   "devDependencies": {
-    "@types/cookie-parser": "^1.4.9",
     "@types/bcryptjs": "^2.4.2",
+    "@types/cookie-parser": "^1.4.9",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.11",
     "@types/jsonwebtoken": "^9.0.6",

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -2,9 +2,11 @@ import { Request, Response, NextFunction } from 'express';
 
 export class HttpError extends Error {
   status: number;
-  constructor(status: number, message: string) {
+  details?: unknown;
+  constructor(status: number, message: string, details?: unknown) {
     super(message);
     this.status = status;
+    this.details = details;
   }
 }
 
@@ -16,10 +18,12 @@ export function errorHandler(
 ) {
   let status = 500;
   let message = 'Internal Server Error';
+  let details: unknown;
 
   if (err instanceof HttpError) {
     status = err.status || 500;
     message = err.message || message;
+    details = err.details;
   } else {
     // Log unexpected errors to aid debugging
     console.error(err);
@@ -28,5 +32,9 @@ export function errorHandler(
     }
   }
 
-  res.status(status).json({ error: { message } });
+  const body: any = { message };
+  if (details !== undefined) {
+    body.details = details;
+  }
+  res.status(status).json({ error: body });
 }

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodTypeAny, ZodIssue } from 'zod';
+import { HttpError } from './errorHandler';
+
+export function validate(schema: ZodTypeAny) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      const details = result.error.issues.map((issue: ZodIssue) => ({
+        path: issue.path.join('.'),
+        message: issue.message,
+      }));
+      return next(new HttpError(400, 'Validation error', details));
+    }
+    req.body = result.data;
+    return next();
+  };
+}

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1,25 +1,34 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { validate } from '../middleware/validate';
 
 const router = Router();
 
-router.post('/', (req: Request, res: Response) => {
-  try {
-    const required = ['name', 'client', 'location', 'creator_name', 'creator_email'];
-    const missing = required.find((f) => !req.body || !req.body[f]);
-    if (missing) {
-      return res.status(400).json({ error: `${missing} required` });
-    }
-    return res.json({});
-  } catch (err) {
-    return res.status(500).json({ error: 'Internal Server Error' });
-  }
+const createProjectSchema = z.object({
+  name: z.string(),
+  client: z.string(),
+  location: z.string(),
+  creator_name: z.string(),
+  creator_email: z.string().email(),
 });
 
-router.get('/', (_req: Request, res: Response) => {
+router.post(
+  '/',
+  validate(createProjectSchema),
+  (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      return res.json({});
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+router.get('/', (_req: Request, res: Response, next: NextFunction) => {
   try {
     return res.json([]);
   } catch (err) {
-    return res.status(500).json({ error: 'Internal Server Error' });
+    return next(err);
   }
 });
 

--- a/backend/tests/projects.test.ts
+++ b/backend/tests/projects.test.ts
@@ -1,0 +1,35 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+jest.mock('../src/db', () => ({ prisma: {} }));
+import app from '../src/index';
+
+const token = jwt.sign({ account_id: 'acc', role: 'Viewer' }, 'test-secret');
+
+describe('POST /projects', () => {
+  it('creates a project with valid payload', async () => {
+    const res = await request(app)
+      .post('/projects')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Project',
+        client: 'Client',
+        location: 'Location',
+        creator_name: 'Alice',
+        creator_email: 'alice@example.com',
+      });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 on invalid payload', async () => {
+    const res = await request(app)
+      .post('/projects')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Project',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toBe('Validation error');
+    expect(Array.isArray(res.body.error.details)).toBe(true);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "cookie-parser": "^1.4.7",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
-        "prisma": "^6.14.0"
+        "prisma": "^6.14.0",
+        "zod": "^4.1.1"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.2",
@@ -11321,6 +11322,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.1.tgz",
+      "integrity": "sha512-SgMZK/h8Tigt9nnKkfJMvB/mKjiJXaX26xegP4sa+0wHIFVFWVlsQGdhklDmuargBD3Hsi3rsQRIzwJIhTPJHA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }


### PR DESCRIPTION
## Summary
- add zod and a reusable validation middleware
- validate project creation payloads and return structured errors
- test project route validation scenarios

## Testing
- `npm test --workspace backend`

------
https://chatgpt.com/codex/tasks/task_e_68aba034bd0483259a36f3a2623a44df