### PR TITLE
Add project role-based access checks

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -4,6 +4,8 @@ import jwt from 'jsonwebtoken';
 export interface AuthUser {
   account_id: string;
   role: string;
+  project_contact_id: string;
+  project_roles: Record<string, string>;
 }
 
 export interface AuthenticatedRequest extends Request {
@@ -30,6 +32,8 @@ export const authMiddleware = (allowedRoles: string[] = []) => {
       (req as AuthenticatedRequest).user = {
         account_id: payload.account_id,
         role: payload.role,
+        project_contact_id: payload.project_contact_id,
+        project_roles: payload.project_roles || {},
       };
       if (allowedRoles.length && !allowedRoles.includes(payload.role)) {
         return res.status(403).json({ error: 'Forbidden' });

--- a/backend/src/middleware/projectAccess.ts
+++ b/backend/src/middleware/projectAccess.ts
@@ -1,0 +1,35 @@
+import { Request, Response, NextFunction } from 'express';
+import { prisma } from '../db';
+import { AuthenticatedRequest } from './auth';
+
+export const projectAccessMiddleware = (allowedRoles: string[] = []) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const { user } = req as AuthenticatedRequest;
+    const { project_id } = req.params as { project_id?: string };
+
+    if (!user || !project_id) {
+      return res.status(400).json({ error: 'project_id required' });
+    }
+
+    if (user.role === 'AccountAdmin' && allowedRoles.includes('AccountAdmin')) {
+      return next();
+    }
+
+    try {
+      const access = await prisma.projectAccess.findFirst({
+        where: {
+          project_id,
+          project_contact_id: user.project_contact_id,
+          account_id: user.account_id,
+        },
+      });
+      const role = access?.role as string | undefined;
+      if (!role || (allowedRoles.length && !allowedRoles.includes(role))) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+      return next();
+    } catch (err) {
+      return res.status(500).json({ error: 'Failed to verify project access' });
+    }
+  };
+};

--- a/backend/src/routes/authLogin.ts
+++ b/backend/src/routes/authLogin.ts
@@ -22,11 +22,20 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
     ) {
       return res.status(401).json({ error: 'Invalid credentials' });
     }
+    const accesses = await prisma.projectAccess.findMany({
+      where: { project_contact_id: contact.project_contact_id },
+      select: { project_id: true, role: true },
+    });
+    const project_roles: Record<string, string> = {};
+    accesses.forEach((a: { project_id: string; role: string }) => {
+      project_roles[a.project_id] = a.role;
+    });
     const token = jwt.sign(
       {
         account_id: contact.account_id,
         project_contact_id: contact.project_contact_id,
         role: contact.role || '',
+        project_roles,
       },
       JWT_SECRET,
       { expiresIn: '1h' },
@@ -42,6 +51,7 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
         account_id: contact.account_id,
         project_contact_id: contact.project_contact_id,
         role: contact.role || '',
+        project_roles,
       },
     });
   } catch (err) {

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -16,6 +16,7 @@ import projectSubscriptions from './projectSubscriptions';
 import billing from './billing';
 import { authMiddleware } from '../middleware/auth';
 import { routePermissions } from '../middleware/permissions';
+import { projectAccessMiddleware } from '../middleware/projectAccess';
 
 const router = Router();
 
@@ -25,52 +26,68 @@ router.use('/accounts', authMiddleware(routePermissions['/accounts']), accounts)
 router.use('/projects', authMiddleware(routePermissions['/projects']), projects);
 router.use(
   '/projects/:project_id/owner',
-  authMiddleware(routePermissions['/projects/:project_id/owner']),
+  authMiddleware(),
+  projectAccessMiddleware(routePermissions['/projects/:project_id/owner']),
   projectOwner
 );
 router.use(
   '/projects/:project_id/contacts',
-  authMiddleware(routePermissions['/projects/:project_id/contacts']),
+  authMiddleware(),
+  projectAccessMiddleware(routePermissions['/projects/:project_id/contacts']),
   projectContacts
 );
 router.use(
   '/projects/:project_id/contacts/:project_contact_id/scopes',
-  authMiddleware(routePermissions['/projects/:project_id/contacts/:project_contact_id/scopes']),
+  authMiddleware(),
+  projectAccessMiddleware(
+    routePermissions['/projects/:project_id/contacts/:project_contact_id/scopes']
+  ),
   contactScopes
 );
 router.use(
   '/projects/:project_id/flags',
-  authMiddleware(routePermissions['/projects/:project_id/flags']),
+  authMiddleware(),
+  projectAccessMiddleware(routePermissions['/projects/:project_id/flags']),
   projectFlags
 );
 router.use(
   '/projects/:project_id/photos',
-  authMiddleware(routePermissions['/projects/:project_id/photos']),
+  authMiddleware(),
+  projectAccessMiddleware(routePermissions['/projects/:project_id/photos']),
   projectPhotos
 );
 router.use(
   '/projects/:project_id/flags/:flag_id/photos',
-  authMiddleware(routePermissions['/projects/:project_id/flags/:flag_id/photos']),
+  authMiddleware(),
+  projectAccessMiddleware(
+    routePermissions['/projects/:project_id/flags/:flag_id/photos']
+  ),
   flagPhotos
 );
 router.use(
   '/projects/:project_id/report-templates',
-  authMiddleware(routePermissions['/projects/:project_id/report-templates']),
+  authMiddleware(),
+  projectAccessMiddleware(routePermissions['/projects/:project_id/report-templates']),
   reportTemplates
 );
 router.use(
   '/projects/:project_id/report-templates/:template_id/generate',
-  authMiddleware(routePermissions['/projects/:project_id/report-templates/:template_id/generate']),
+  authMiddleware(),
+  projectAccessMiddleware(
+    routePermissions['/projects/:project_id/report-templates/:template_id/generate']
+  ),
   reportTemplateGenerate
 );
 router.use(
   '/projects/:project_id/schedule',
-  authMiddleware(routePermissions['/projects/:project_id/schedule']),
+  authMiddleware(),
+  projectAccessMiddleware(routePermissions['/projects/:project_id/schedule']),
   projectSchedule
 );
 router.use(
   '/projects/:project_id/subscriptions',
-  authMiddleware(routePermissions['/projects/:project_id/subscriptions']),
+  authMiddleware(),
+  projectAccessMiddleware(routePermissions['/projects/:project_id/subscriptions']),
   projectSubscriptions
 );
 router.use('/billing', authMiddleware(routePermissions['/billing']), billing);

--- a/backend/tests/authLogin.test.ts
+++ b/backend/tests/authLogin.test.ts
@@ -7,6 +7,9 @@ jest.mock('../src/db', () => ({
     projectContact: {
       findUnique: jest.fn(),
     },
+    projectAccess: {
+      findMany: jest.fn(),
+    },
   },
 }));
 
@@ -26,6 +29,9 @@ describe('POST /auth/login', () => {
       role: 'Viewer',
       password_hash: hash,
     });
+    (prisma.projectAccess.findMany as jest.Mock).mockResolvedValue([
+      { project_id: 'proj1', role: 'Viewer' },
+    ]);
 
     const res = await request(app)
       .post('/auth/login')
@@ -37,6 +43,7 @@ describe('POST /auth/login', () => {
       account_id: 'acc1',
       project_contact_id: 'pc1',
       role: 'Viewer',
+      project_roles: { proj1: 'Viewer' },
     });
   });
 
@@ -48,6 +55,9 @@ describe('POST /auth/login', () => {
       role: 'Viewer',
       password_hash: hash,
     });
+    (prisma.projectAccess.findMany as jest.Mock).mockResolvedValue([
+      { project_id: 'proj1', role: 'Viewer' },
+    ]);
 
     const res = await request(app)
       .post('/auth/login')
@@ -58,6 +68,7 @@ describe('POST /auth/login', () => {
 
   it('rejects when project scope does not match', async () => {
     (prisma.projectContact.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.projectAccess.findMany as jest.Mock).mockResolvedValue([]);
 
     const res = await request(app)
       .post('/auth/login')


### PR DESCRIPTION
## Summary
- include project contact ID and per-project roles in login JWT/session
- verify roles against `ProjectAccess` via new middleware
- apply project access checks across project-scoped routes

## Testing
- `npm test --workspace backend`


------
https://chatgpt.com/codex/tasks/task_e_68aba00c672c83259259d5af2523dab9