### PR TITLE
Scope project routes by account

### DIFF
--- a/backend/src/routes/billing.ts
+++ b/backend/src/routes/billing.ts
@@ -1,19 +1,24 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { AuthenticatedRequest } from '../middleware/auth';
+import { HttpError } from '../middleware/errorHandler';
 
 const router = Router();
 
 // Stub endpoint to create a subscription. In production this would
 // integrate with Stripe's subscription APIs.
-router.post('/subscribe', (req: Request, res: Response) => {
+router.post('/subscribe', (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { account_id, plan } = req.body || {};
-    if (!account_id || !plan) {
-      return res.status(400).json({ error: 'account_id and plan required' });
+    const { plan } = req.body || {};
+    const { user } = req as AuthenticatedRequest;
+    if (!plan) {
+      return next(new HttpError(400, 'plan required'));
     }
-    // Placeholder response until billing logic is implemented
-    return res.json({});
+    // Placeholder response until billing logic is implemented. The
+    // account context comes from the authenticated user.
+    const account_id = user?.account_id;
+    return res.json({ account_id });
   } catch (err) {
-    return res.status(500).json({ error: 'Internal Server Error' });
+    return next(new HttpError(500, 'Internal Server Error'));
   }
 });
 

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1,25 +1,45 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { prisma } from '../db';
+import { HttpError } from '../middleware/errorHandler';
+import { AuthenticatedRequest } from '../middleware/auth';
 
 const router = Router();
 
-router.post('/', (req: Request, res: Response) => {
+// Create a new project scoped to the authenticated user's account
+router.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  const required = ['name', 'client', 'location', 'creator_name', 'creator_email'];
+  const missing = required.find((f) => !req.body || !req.body[f]);
+  if (missing) {
+    return next(new HttpError(400, `${missing} required`));
+  }
   try {
-    const required = ['name', 'client', 'location', 'creator_name', 'creator_email'];
-    const missing = required.find((f) => !req.body || !req.body[f]);
-    if (missing) {
-      return res.status(400).json({ error: `${missing} required` });
-    }
-    return res.json({});
+    const { user } = req as AuthenticatedRequest;
+    const project = await prisma.project.create({
+      data: {
+        name: req.body.name,
+        client: req.body.client,
+        location: req.body.location,
+        creator_name: req.body.creator_name,
+        creator_email: req.body.creator_email,
+        account_id: user!.account_id,
+      },
+    });
+    return res.json(project);
   } catch (err) {
-    return res.status(500).json({ error: 'Internal Server Error' });
+    return next(new HttpError(500, 'Failed to create project'));
   }
 });
 
-router.get('/', (_req: Request, res: Response) => {
+// List projects for the authenticated user's account
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    return res.json([]);
+    const { user } = req as AuthenticatedRequest;
+    const projects = await prisma.project.findMany({
+      where: { account_id: user!.account_id },
+    });
+    return res.json(projects);
   } catch (err) {
-    return res.status(500).json({ error: 'Internal Server Error' });
+    return next(new HttpError(500, 'Failed to fetch projects'));
   }
 });
 

--- a/backend/tests/projects.test.ts
+++ b/backend/tests/projects.test.ts
@@ -1,0 +1,79 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import app from '../src/index';
+
+jest.mock('../src/db', () => ({
+  prisma: {
+    project: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+const { prisma } = require('../src/db');
+
+const tokenFor = (account_id: string) =>
+  jwt.sign({ account_id, role: 'Viewer' }, process.env.JWT_SECRET || 'test-secret');
+
+describe('Projects routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('scopes project creation to user account', async () => {
+    (prisma.project.create as jest.Mock).mockResolvedValue({
+      project_id: 'p1',
+      account_id: 'acc1',
+    });
+
+    const res = await request(app)
+      .post('/projects')
+      .set('Authorization', `Bearer ${tokenFor('acc1')}`)
+      .send({
+        name: 'Name',
+        client: 'Client',
+        location: 'Loc',
+        creator_name: 'Creator',
+        creator_email: 'creator@example.com',
+        account_id: 'acc2',
+      });
+
+    expect(res.status).toBe(200);
+    expect(prisma.project.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ account_id: 'acc1' }),
+    });
+  });
+
+  it('scopes project listing to user account', async () => {
+    (prisma.project.findMany as jest.Mock).mockResolvedValue([
+      { project_id: 'p1', account_id: 'acc1', name: 'Name' },
+    ]);
+
+    const res = await request(app)
+      .get('/projects')
+      .set('Authorization', `Bearer ${tokenFor('acc1')}`);
+
+    expect(res.status).toBe(200);
+    expect(prisma.project.findMany).toHaveBeenCalledWith({
+      where: { account_id: 'acc1' },
+    });
+    expect(res.body).toEqual([
+      { project_id: 'p1', account_id: 'acc1', name: 'Name' },
+    ]);
+  });
+
+  it('prevents cross-tenant access', async () => {
+    (prisma.project.findMany as jest.Mock).mockResolvedValue([]);
+
+    const res = await request(app)
+      .get('/projects')
+      .set('Authorization', `Bearer ${tokenFor('acc2')}`);
+
+    expect(res.status).toBe(200);
+    expect(prisma.project.findMany).toHaveBeenCalledWith({
+      where: { account_id: 'acc2' },
+    });
+    expect(res.body).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Scope project creation and listing to the authenticated account
- Attach account context to billing subscription endpoint
- Test that projects cannot be created or listed across tenants

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aba002fcac8325b3e7d427e0869a32