### PR TITLE
Persist workflow events with Prisma

### DIFF
--- a/backend/prisma/migrations/0001_add_audit_notification_events/migration.sql
+++ b/backend/prisma/migrations/0001_add_audit_notification_events/migration.sql
@@ -1,0 +1,30 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE "NotificationEvent" (
+  "event_id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "type" TEXT NOT NULL,
+  "project_id" TEXT NOT NULL,
+  "entity_type" TEXT,
+  "entity_id" TEXT,
+  "payload" JSONB,
+  "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "delivered_to" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "account_id" TEXT NOT NULL
+);
+
+CREATE INDEX "NotificationEvent_account_id_idx" ON "NotificationEvent" ("account_id");
+CREATE INDEX "NotificationEvent_project_id_idx" ON "NotificationEvent" ("project_id");
+
+CREATE TABLE "AuditEvent" (
+  "event_id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "actor" TEXT NOT NULL,
+  "action" TEXT NOT NULL,
+  "entity" TEXT NOT NULL,
+  "entity_id" TEXT NOT NULL,
+  "before" JSONB,
+  "after" JSONB,
+  "at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "account_id" TEXT NOT NULL
+);
+
+CREATE INDEX "AuditEvent_account_id_idx" ON "AuditEvent" ("account_id");

--- a/backend/prisma/migrations/migration_lock.toml
+++ b/backend/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma migration lockfile
+provider = "postgresql"

--- a/backend/src/audit.ts
+++ b/backend/src/audit.ts
@@ -1,63 +1,56 @@
-export interface AuditEvent {
-  entity: string;
-  action: 'create' | 'update';
-  actor: string;
-  entityId: string;
-  timestamp: Date;
-  changes?: Record<string, { before: any; after: any }>;
-}
+import { AuditEvent } from '@prisma/client'
+import { prisma } from './db'
 
-const auditLog: AuditEvent[] = [];
-
-export function logCreate(
+export async function logCreate(
+  accountId: string,
   entity: string,
   entityId: string,
   actor: string,
   data: Record<string, any>
-): AuditEvent {
-  const changes: Record<string, { before: any; after: any }> = {};
-  for (const [key, value] of Object.entries(data)) {
-    changes[key] = { before: undefined, after: value };
-  }
-  const event: AuditEvent = {
-    entity,
-    entityId,
-    actor,
-    action: 'create',
-    timestamp: new Date(),
-    changes,
-  };
-  auditLog.push(event);
-  console.log(`AUDIT create ${entity} ${entityId}`);
-  return event;
+): Promise<AuditEvent> {
+  const event = await prisma.auditEvent.create({
+    data: {
+      account_id: accountId,
+      actor,
+      action: 'create',
+      entity,
+      entity_id: entityId,
+      before: {},
+      after: data,
+      at: new Date(),
+    },
+  })
+  console.log(`AUDIT create ${entity} ${entityId}`)
+  return event
 }
 
-export function logUpdate(
+export async function logUpdate(
+  accountId: string,
   entity: string,
   entityId: string,
   actor: string,
   before: Record<string, any>,
   after: Record<string, any>
-): AuditEvent {
-  const changes: Record<string, { before: any; after: any }> = {};
-  for (const key of Object.keys(after)) {
-    if (before[key] !== after[key]) {
-      changes[key] = { before: before[key], after: after[key] };
-    }
-  }
-  const event: AuditEvent = {
-    entity,
-    entityId,
-    actor,
-    action: 'update',
-    timestamp: new Date(),
-    changes,
-  };
-  auditLog.push(event);
-  console.log(`AUDIT update ${entity} ${entityId}`);
-  return event;
+): Promise<AuditEvent> {
+  const event = await prisma.auditEvent.create({
+    data: {
+      account_id: accountId,
+      actor,
+      action: 'update',
+      entity,
+      entity_id: entityId,
+      before,
+      after,
+      at: new Date(),
+    },
+  })
+  console.log(`AUDIT update ${entity} ${entityId}`)
+  return event
 }
 
-export function getAuditLog(): AuditEvent[] {
-  return auditLog;
+export function getAuditLog(accountId: string): Promise<AuditEvent[]> {
+  return prisma.auditEvent.findMany({
+    where: { account_id: accountId },
+    orderBy: { at: 'desc' },
+  })
 }

--- a/backend/src/notifications/dispatcher.ts
+++ b/backend/src/notifications/dispatcher.ts
@@ -1,23 +1,40 @@
+import { NotificationEvent as DBNotificationEvent } from '@prisma/client'
+import { prisma } from '../db'
+
 export interface NotificationEvent {
-  type: string;
-  recipient: string;
-  subject: string;
-  body: string;
-  timestamp: Date;
+  type: string
+  recipient: string
+  subject: string
+  body: string
+  timestamp: Date
+  project_id: string
+  account_id: string
 }
 
-const events: NotificationEvent[] = [];
-
 export async function dispatch(event: NotificationEvent): Promise<void> {
-  events.push(event);
-  await sendEmail(event);
+  await prisma.notificationEvent.create({
+    data: {
+      type: event.type,
+      project_id: event.project_id,
+      entity_type: null,
+      entity_id: null,
+      payload: { recipient: event.recipient, subject: event.subject, body: event.body },
+      created_at: event.timestamp,
+      delivered_to: [event.recipient],
+      account_id: event.account_id,
+    },
+  })
+  await sendEmail(event)
 }
 
 async function sendEmail(event: NotificationEvent): Promise<void> {
   // Email send stub
-  console.log(`Email to ${event.recipient}: ${event.subject}`);
+  console.log(`Email to ${event.recipient}: ${event.subject}`)
 }
 
-export function getDispatchedEvents(): NotificationEvent[] {
-  return events;
+export function getDispatchedEvents(accountId: string): Promise<DBNotificationEvent[]> {
+  return prisma.notificationEvent.findMany({
+    where: { account_id: accountId },
+    orderBy: { created_at: 'desc' },
+  })
 }

--- a/backend/src/workflows/engine.ts
+++ b/backend/src/workflows/engine.ts
@@ -2,16 +2,17 @@ import { dispatch, NotificationEvent } from '../notifications/dispatcher';
 import { logCreate, logUpdate } from '../audit';
 
 export interface SideEffect {
-  type: 'notification';
-  notification: Omit<NotificationEvent, 'timestamp'>;
+  type: 'notification'
+  notification: Omit<NotificationEvent, 'timestamp'>
 }
 
 export interface WorkflowContext {
-  actor: string;
-  entity: string;
-  entityId: string;
-  before?: Record<string, any>;
-  after: Record<string, any>;
+  accountId: string
+  actor: string
+  entity: string
+  entityId: string
+  before?: Record<string, any>
+  after: Record<string, any>
 }
 
 export async function runWorkflow(
@@ -25,8 +26,8 @@ export async function runWorkflow(
   }
 
   if (ctx.before) {
-    logUpdate(ctx.entity, ctx.entityId, ctx.actor, ctx.before, ctx.after);
+    await logUpdate(ctx.accountId, ctx.entity, ctx.entityId, ctx.actor, ctx.before, ctx.after);
   } else {
-    logCreate(ctx.entity, ctx.entityId, ctx.actor, ctx.after);
+    await logCreate(ctx.accountId, ctx.entity, ctx.entityId, ctx.actor, ctx.after);
   }
 }

--- a/backend/tests/workflowPersistence.test.ts
+++ b/backend/tests/workflowPersistence.test.ts
@@ -1,0 +1,54 @@
+import { execSync } from 'child_process'
+process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/crewdex_test'
+
+const { prisma } = require('../src/db')
+const { runWorkflow } = require('../src/workflows/engine')
+
+beforeAll(() => {
+  execSync('npx prisma migrate deploy', { cwd: __dirname + '/..', stdio: 'inherit', env: process.env })
+})
+
+afterEach(async () => {
+  await prisma.auditEvent.deleteMany()
+  await prisma.notificationEvent.deleteMany()
+})
+
+afterAll(async () => {
+  await prisma.$disconnect()
+})
+
+describe('runWorkflow persistence', () => {
+  it('persists audit and notification events', async () => {
+    const sideEffects = [
+      {
+        type: 'notification' as const,
+        notification: {
+          type: 'email',
+          recipient: 'user@example.com',
+          subject: 'Hello',
+          body: 'World',
+          project_id: 'proj1',
+          account_id: 'acc1',
+        },
+      },
+    ]
+
+    const ctx = {
+      accountId: 'acc1',
+      actor: 'user1',
+      entity: 'Project',
+      entityId: 'proj1',
+      after: { name: 'Test Project' },
+    }
+
+    await runWorkflow(sideEffects, ctx)
+
+    const audits = await prisma.auditEvent.findMany({ where: { account_id: 'acc1' } })
+    expect(audits).toHaveLength(1)
+    expect(audits[0].entity).toBe('Project')
+
+    const notifications = await prisma.notificationEvent.findMany({ where: { account_id: 'acc1' } })
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0].type).toBe('email')
+  })
+})


### PR DESCRIPTION
## Summary
- replace in-memory audit and notification logs with Prisma-backed persistence
- add migration for `AuditEvent` and `NotificationEvent` tables including `account_id`
- test workflow run stores audit and notification events

## Testing
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68aba029bef88325b64bfeea3c0140f4