### PR TITLE
feat(ui): default button type

### DIFF
--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils';
 export function Button({ className, ...props }) {
   return (
     <button
+      type={props.type || 'button'}
       className={cn(
         'inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         className


### PR DESCRIPTION
## Summary
- prevent accidental form submissions by defaulting Button component's type to `button`

## Testing
- `npm test --workspace backend` *(fails: PrismaClient cannot connect, missing database)*
- `npm test --workspace frontend`
- `npm run lint --workspace frontend`
- `npm run build --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68aba6bcc5a08325a6252f2fd5bce2c2