### PR TITLE
Enforce JWT secret in login route and tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
+  setupFiles: ['<rootDir>/tests/setupEnv.ts'],
 };

--- a/backend/src/routes/authLogin.ts
+++ b/backend/src/routes/authLogin.ts
@@ -5,7 +5,10 @@ import { prisma } from '../db';
 import { HttpError } from '../middleware/errorHandler';
 
 const router = Router();
-const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is not set');
+}
 
 router.post('/', async (req: Request, res: Response, next: NextFunction) => {
   const { email, password, project_id } = req.body || {};

--- a/backend/tests/setupEnv.ts
+++ b/backend/tests/setupEnv.ts
@@ -1,0 +1,2 @@
+process.env.JWT_SECRET = 'test-secret';
+


### PR DESCRIPTION
## Summary
- Fail fast when `JWT_SECRET` is missing in auth login route
- Configure Jest to inject `JWT_SECRET` during tests

## Testing
- `npm test --workspace backend` *(fails: P1001 Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68aba6b6a12083258f091b01f6203b1d