### PR TITLE
feat: scope projects to account

### DIFF
--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1,6 +1,9 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { validate } from '../middleware/validate';
+import { prisma } from '../db';
+import { HttpError } from '../middleware/errorHandler';
+import { AuthenticatedRequest } from '../middleware/auth';
 
 const router = Router();
 
@@ -15,20 +18,28 @@ const createProjectSchema = z.object({
 router.post(
   '/',
   validate(createProjectSchema),
-  (_req: Request, res: Response, next: NextFunction) => {
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { user } = req as AuthenticatedRequest;
     try {
-      return res.json({});
+      const project = await prisma.project.create({
+        data: { ...req.body, account_id: user?.account_id },
+      });
+      return res.json(project);
     } catch (err) {
-      return next(err);
+      return next(new HttpError(500, 'Failed to create project'));
     }
   },
 );
 
-router.get('/', (_req: Request, res: Response, next: NextFunction) => {
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  const { user } = req as AuthenticatedRequest;
   try {
-    return res.json([]);
+    const projects = await prisma.project.findMany({
+      where: { account_id: user?.account_id },
+    });
+    return res.json(projects);
   } catch (err) {
-    return next(err);
+    return next(new HttpError(500, 'Failed to fetch projects'));
   }
 });
 

--- a/backend/tests/projects.test.ts
+++ b/backend/tests/projects.test.ts
@@ -1,24 +1,44 @@
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 
-jest.mock('../src/db', () => ({ prisma: {} }));
+const createMock = jest.fn();
+const findManyMock = jest.fn();
+
+jest.mock('../src/db', () => ({
+  prisma: {
+    project: {
+      create: createMock,
+      findMany: findManyMock,
+    },
+  },
+}));
 import app from '../src/index';
 
 const token = jwt.sign({ account_id: 'acc', role: 'Viewer' }, 'test-secret');
 
+beforeEach(() => {
+  createMock.mockReset();
+  findManyMock.mockReset();
+});
+
 describe('POST /projects', () => {
-  it('creates a project with valid payload', async () => {
+  it('persists account_id for tenant isolation', async () => {
+    createMock.mockResolvedValue({ project_id: 'p1', account_id: 'acc' });
+    const payload = {
+      name: 'Project',
+      client: 'Client',
+      location: 'Location',
+      creator_name: 'Alice',
+      creator_email: 'alice@example.com',
+    };
     const res = await request(app)
       .post('/projects')
       .set('Authorization', `Bearer ${token}`)
-      .send({
-        name: 'Project',
-        client: 'Client',
-        location: 'Location',
-        creator_name: 'Alice',
-        creator_email: 'alice@example.com',
-      });
+      .send(payload);
     expect(res.status).toBe(200);
+    expect(createMock).toHaveBeenCalledWith({
+      data: { ...payload, account_id: 'acc' },
+    });
   });
 
   it('returns 400 on invalid payload', async () => {
@@ -31,5 +51,24 @@ describe('POST /projects', () => {
     expect(res.status).toBe(400);
     expect(res.body.error.message).toBe('Validation error');
     expect(Array.isArray(res.body.error.details)).toBe(true);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /projects', () => {
+  it('filters projects by account_id', async () => {
+    findManyMock.mockResolvedValue([
+      { project_id: 'p1', name: 'Proj', account_id: 'acc' },
+    ]);
+    const res = await request(app)
+      .get('/projects')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: { account_id: 'acc' },
+    });
+    expect(res.body).toEqual([
+      { project_id: 'p1', name: 'Proj', account_id: 'acc' },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- persist projects with authenticated `account_id`
- filter project list by requesting user's account
- add tests to ensure project endpoints respect tenant isolation

## Testing
- `npm test --workspace backend` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68aba6c642b08325b31ccbdcbbc3f6c0