### PR TITLE
feat: validate login payload

### DIFF
--- a/backend/src/routes/authLogin.ts
+++ b/backend/src/routes/authLogin.ts
@@ -1,8 +1,10 @@
 import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 import { prisma } from '../db';
 import { HttpError } from '../middleware/errorHandler';
+import { validate } from '../middleware/validate';
 
 const router = Router();
 const JWT_SECRET = process.env.JWT_SECRET;
@@ -10,56 +12,65 @@ if (!JWT_SECRET) {
   throw new Error('JWT_SECRET environment variable is not set');
 }
 
-router.post('/', async (req: Request, res: Response, next: NextFunction) => {
-  const { email, password, project_id } = req.body || {};
-  if (!email || !password || !project_id) {
-    return next(new HttpError(400, 'email, password and project_id required'));
-  }
-  try {
-    const contact: any = await prisma.projectContact.findUnique({
-      where: { project_id_email: { project_id, email } },
-    });
-    if (
-      !contact ||
-      !(await bcrypt.compare(password, contact.password_hash || ''))
-    ) {
-      return res.status(401).json({ error: 'Invalid credentials' });
-    }
-    const accesses = await prisma.projectAccess.findMany({
-      where: { project_contact_id: contact.project_contact_id },
-      select: { project_id: true, role: true },
-    });
-    const project_roles: Record<string, string> = {};
-    accesses.forEach((a: { project_id: string; role: string }) => {
-      project_roles[a.project_id] = a.role;
-    });
-    const token = jwt.sign(
-      {
-        account_id: contact.account_id,
-        project_contact_id: contact.project_contact_id,
-        role: contact.role || '',
-        project_roles,
-      },
-      JWT_SECRET,
-      { expiresIn: '1h' },
-    );
-    res.cookie('token', token, {
-      httpOnly: true,
-      sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
-      maxAge: 60 * 60 * 1000,
-    });
-    return res.json({
-      session: {
-        account_id: contact.account_id,
-        project_contact_id: contact.project_contact_id,
-        role: contact.role || '',
-        project_roles,
-      },
-    });
-  } catch (err) {
-    return next(new HttpError(500, 'Login failed'));
-  }
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+  project_id: z.string(),
 });
+
+type LoginPayload = z.infer<typeof loginSchema>;
+
+router.post(
+  '/',
+  validate(loginSchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { email, password, project_id } = req.body as LoginPayload;
+    try {
+      const contact: any = await prisma.projectContact.findUnique({
+        where: { project_id_email: { project_id, email } },
+      });
+      if (
+        !contact ||
+        !(await bcrypt.compare(password, contact.password_hash || ''))
+      ) {
+        return res.status(401).json({ error: 'Invalid credentials' });
+      }
+      const accesses = await prisma.projectAccess.findMany({
+        where: { project_contact_id: contact.project_contact_id },
+        select: { project_id: true, role: true },
+      });
+      const project_roles: Record<string, string> = {};
+      accesses.forEach((a: { project_id: string; role: string }) => {
+        project_roles[a.project_id] = a.role;
+      });
+      const token = jwt.sign(
+        {
+          account_id: contact.account_id,
+          project_contact_id: contact.project_contact_id,
+          role: contact.role || '',
+          project_roles,
+        },
+        JWT_SECRET,
+        { expiresIn: '1h' },
+      );
+      res.cookie('token', token, {
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: 60 * 60 * 1000,
+      });
+      return res.json({
+        session: {
+          account_id: contact.account_id,
+          project_contact_id: contact.project_contact_id,
+          role: contact.role || '',
+          project_roles,
+        },
+      });
+    } catch (err) {
+      return next(new HttpError(500, 'Login failed'));
+    }
+  },
+);
 
 export default router;

--- a/backend/tests/authLogin.test.ts
+++ b/backend/tests/authLogin.test.ts
@@ -76,4 +76,24 @@ describe('POST /auth/login', () => {
 
     expect(res.status).toBe(401);
   });
+
+  it('rejects missing fields', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'user@example.com', project_id: 'proj1' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid email format', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({
+        email: 'not-an-email',
+        password: 'secret',
+        project_id: 'proj1',
+      });
+
+    expect(res.status).toBe(400);
+  });
 });


### PR DESCRIPTION
## Summary
- validate login requests using a zod schema
- add tests for missing fields and invalid email

## Testing
- `pnpm test tests/authLogin.test.ts`
- `pnpm test` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68aba9903b9c832591c0e412d2257fc9