### PR TITLE
feat: cap offline queue retries

### DIFF
--- a/frontend/src/lib/offlineQueue.test.js
+++ b/frontend/src/lib/offlineQueue.test.js
@@ -79,3 +79,19 @@ test('flushQueue requeues failed requests with retry metadata', async () => {
   expect(requests[0].retryCount).toBe(1);
   expect(typeof requests[0].nextRetryAt).toBe('number');
 });
+
+test('flushQueue drops requests after exceeding max retries', async () => {
+  await addRequest({
+    url: '/fail',
+    method: 'POST',
+    headers: {},
+    body: '{}',
+    retryCount: 5,
+  });
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ ok: false, status: 500, statusText: 'Error' });
+  await flushQueue();
+  const requests = await getAllRequests();
+  expect(requests).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary
- add MAX_RETRIES and drop requests after exceeding retry threshold
- cover exceeding retry cap in offline queue tests

## Testing
- `pnpm --filter frontend test`
- `pnpm --filter frontend lint` *(fails: 'jest' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68abad2142ec8325b50bb886c0a873cc