### PR TITLE
feat: fetch projects with react query

### DIFF
--- a/frontend/src/pages/ProjectList.jsx
+++ b/frontend/src/pages/ProjectList.jsx
@@ -1,9 +1,25 @@
 import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import ResponsiveLayout from '@/components/ResponsiveLayout';
 import ResponsiveList from '@/components/ResponsiveList';
 
 export default function ProjectList() {
-  const projects = [{ id: '1', name: 'Demo Project' }];
+  const {
+    data: projects = [],
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['projects'],
+    queryFn: async () => {
+      const res = await fetch('/api/projects');
+      if (!res.ok) throw new Error('Failed to load projects');
+      return res.json();
+    },
+    staleTime: Infinity,
+    gcTime: Infinity,
+    networkMode: 'offlineFirst',
+  });
+
   const columns = [
     {
       key: 'name',
@@ -11,10 +27,15 @@ export default function ProjectList() {
       render: (p) => <Link to={`/projects/${p.id}`}>{p.name}</Link>,
     },
   ];
+
   return (
     <ResponsiveLayout sidebar={<div>Sidebar</div>}>
       <h1 className="mb-4 text-xl font-bold">Projects</h1>
-      <ResponsiveList items={projects} columns={columns} />
+      {isLoading && <p>Loading...</p>}
+      {isError && <p>Error loading projects</p>}
+      {!isLoading && !isError && (
+        <ResponsiveList items={projects} columns={columns} />
+      )}
     </ResponsiveLayout>
   );
 }


### PR DESCRIPTION
## Summary
- fetch project list via React Query
- show loading and error states with offline-first caching

## Testing
- `pnpm --filter frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68abad1baf108325be0847c98480f9be