### PR TITLE
feat: add account registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ pnpm dev
 
 The `pnpm dev` script launches the backend API and the frontend client concurrently.
 
+## User Registration
+
+New accounts are created through the registration endpoint. Send a `POST` request to `/auth/register` with:
+
+```json
+{
+  "account_name": "My Company",
+  "email": "admin@example.com",
+  "password": "plain-text password"
+}
+```
+
+The server creates the account, stores a bcrypt password hash, and responds with a session token (JWT) in an HTTP-only cookie.
+
 ## Authentication and RBAC
 
 Users authenticate with email, password, and a project ID. Passwords are stored as hashes and verified using `bcrypt.compare`. Successful login issues a JWT containing:

--- a/backend/prisma/migrations/0002_account_user/migration.sql
+++ b/backend/prisma/migrations/0002_account_user/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "public"."AccountUser" (
+    "user_id" TEXT NOT NULL,
+    "account_id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password_hash" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "project_contact_id" TEXT,
+
+    CONSTRAINT "AccountUser_pkey" PRIMARY KEY ("user_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AccountUser_email_key" ON "public"."AccountUser"("email");
+
+-- CreateIndex
+CREATE INDEX "AccountUser_account_id_idx" ON "public"."AccountUser"("account_id");
+
+-- AddForeignKey
+ALTER TABLE "public"."AccountUser" ADD CONSTRAINT "AccountUser_account_id_fkey" FOREIGN KEY ("account_id") REFERENCES "public"."Account"("account_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AccountUser" ADD CONSTRAINT "AccountUser_project_contact_id_fkey" FOREIGN KEY ("project_contact_id") REFERENCES "public"."ProjectContact"("project_contact_id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,36 +11,36 @@ enum UserRoleName {
   ACCOUNT_ADMIN @map("AccountAdmin")
   PROJECT_OWNER @map("ProjectOwner")
   PROJECT_ADMIN @map("ProjectAdmin")
-  VIEWER @map("Viewer")
+  VIEWER        @map("Viewer")
 }
 
 enum ProjectContactVisibility {
-  PUBLIC @map("public")
+  PUBLIC   @map("public")
   INTERNAL @map("internal")
 }
 
 enum FlagKind {
   ON_SITE @map("On Site")
   QUALITY @map("Quality")
-  SAFETY @map("Safety")
+  SAFETY  @map("Safety")
   LAGGING @map("Lagging")
 }
 
 enum FlagDate {
-  TODAY @map("Today")
+  TODAY      @map("Today")
   ENTER_DATE @map("Enter Date")
 }
 
 enum ReportTemplateExport {
-  PDF @map("pdf")
+  PDF  @map("pdf")
   HTML @map("html")
 }
 
 enum ReportType {
-  DAILY @map("Daily")
+  DAILY    @map("Daily")
   INCIDENT @map("Incident")
-  SAFETY @map("Safety")
-  CUSTOM @map("Custom")
+  SAFETY   @map("Safety")
+  CUSTOM   @map("Custom")
 }
 
 enum ReportStatus {
@@ -49,26 +49,26 @@ enum ReportStatus {
 }
 
 enum PunchItemStatus {
-  OPEN @map("open")
+  OPEN        @map("open")
   IN_PROGRESS @map("in_progress")
-  COMPLETE @map("complete")
+  COMPLETE    @map("complete")
 }
 
 enum ChangeOrderStatus {
-  OPEN @map("open")
+  OPEN     @map("open")
   APPROVED @map("approved")
   REJECTED @map("rejected")
 }
 
 enum ChangeOrderOrigin {
-  RFI @map("rfi")
+  RFI   @map("rfi")
   OWNER @map("owner")
   FIELD @map("field")
 }
 
 enum ExternalLinkVisibility {
   PUBLIC @map("public")
-  ADMIN @map("admin")
+  ADMIN  @map("admin")
 }
 
 enum ExternalLinkKind {
@@ -79,23 +79,23 @@ enum ExternalLinkKind {
 
 enum SubscriptionChannel {
   EMAIL @map("email")
-  SMS @map("sms")
+  SMS   @map("sms")
 }
 
 enum SubscriptionFrequency {
   INSTANT @map("instant")
-  DAILY @map("daily")
-  WEEKLY @map("weekly")
+  DAILY   @map("daily")
+  WEEKLY  @map("weekly")
 }
 
 enum AccessRequestStatus {
-  PENDING @map("pending")
+  PENDING  @map("pending")
   APPROVED @map("approved")
-  DENIED @map("denied")
+  DENIED   @map("denied")
 }
 
 enum ProjectAccessRole {
-  VIEWER @map("Viewer")
+  VIEWER        @map("Viewer")
   PROJECT_ADMIN @map("ProjectAdmin")
   PROJECT_OWNER @map("ProjectOwner")
 }
@@ -105,13 +105,28 @@ enum ShareLinkScope {
 }
 
 model Account {
-  account_id String   @id @default(uuid())
+  account_id String        @id @default(uuid())
   name       String
   created_at DateTime?
+  users      AccountUser[]
+}
+
+model AccountUser {
+  user_id            String   @id @default(uuid())
+  account_id         String
+  email              String   @unique
+  password_hash      String
+  created_at         DateTime @default(now())
+  project_contact_id String?
+
+  account         Account         @relation(fields: [account_id], references: [account_id])
+  project_contact ProjectContact? @relation("AccountUserProjectContact", fields: [project_contact_id], references: [project_contact_id])
+
+  @@index([account_id])
 }
 
 model UserRole {
-  role_id     String        @id @default(uuid())
+  role_id     String       @id @default(uuid())
   name        UserRoleName
   permissions String[]
   account_id  String
@@ -120,7 +135,7 @@ model UserRole {
 }
 
 model Project {
-  project_id    String   @id @default(uuid())
+  project_id    String    @id @default(uuid())
   name          String
   number        String?
   client        String?
@@ -135,7 +150,7 @@ model Project {
 }
 
 model ProjectContact {
-  project_contact_id String   @id @default(uuid())
+  project_contact_id String                   @id @default(uuid())
   project_id         String
   name               String
   email              String
@@ -145,6 +160,7 @@ model ProjectContact {
   role               String?
   visibility         ProjectContactVisibility @default(PUBLIC)
   account_id         String
+  account_users      AccountUser[]            @relation("AccountUserProjectContact")
 
   @@unique([project_id, email])
   @@index([account_id])
@@ -185,7 +201,7 @@ model ProjectContactScopeLink {
 }
 
 model Flag {
-  flag_id            String   @id @default(uuid())
+  flag_id            String    @id @default(uuid())
   project_id         String
   project_contact_id String?
   kind               FlagKind
@@ -212,20 +228,20 @@ model FlagPhotoLink {
 }
 
 model ReportTemplate {
-  template_id   String   @id @default(uuid())
-  project_id    String
-  name          String
-  filter        Json?
+  template_id    String                @id @default(uuid())
+  project_id     String
+  name           String
+  filter         Json?
   layout_options Json?
-  export        ReportTemplateExport?
-  account_id    String
+  export         ReportTemplateExport?
+  account_id     String
 
   @@index([account_id])
   @@index([project_id])
 }
 
 model Report {
-  report_id                 String   @id @default(uuid())
+  report_id                 String       @id @default(uuid())
   project_id                String
   reporttype                ReportType
   title                     String?
@@ -261,7 +277,7 @@ model ReportPhotoLink {
 }
 
 model RFI {
-  rfi_id                       String   @id @default(uuid())
+  rfi_id                       String    @id @default(uuid())
   project_id                   String
   subject                      String
   question                     String?
@@ -284,20 +300,20 @@ model RFIPhotoLink {
 }
 
 model Submittal {
-  submittal_id                  String   @id @default(uuid())
-  project_id                    String
-  spec_ref                      String?
-  title                         String?
+  submittal_id                    String    @id @default(uuid())
+  project_id                      String
+  spec_ref                        String?
+  title                           String?
   submitted_by_project_contact_id String?
-  created_at                    DateTime?
-  account_id                    String
+  created_at                      DateTime?
+  account_id                      String
 
   @@index([account_id])
   @@index([project_id])
 }
 
 model SubmittalPhotoLink {
-  id          String @id @default(uuid())
+  id           String @id @default(uuid())
   submittal_id String
   photo_id     String
   account_id   String
@@ -307,14 +323,14 @@ model SubmittalPhotoLink {
 }
 
 model PunchItem {
-  punch_id                   String   @id @default(uuid())
-  project_id                 String
-  location                   String?
-  description                String
-  status                     PunchItemStatus @default(OPEN)
+  punch_id                       String          @id @default(uuid())
+  project_id                     String
+  location                       String?
+  description                    String
+  status                         PunchItemStatus @default(OPEN)
   assigned_to_project_contact_id String?
-  created_at                 DateTime?
-  account_id                 String
+  created_at                     DateTime?
+  account_id                     String
 
   @@index([account_id])
   @@index([project_id])
@@ -331,10 +347,10 @@ model PunchPhotoLink {
 }
 
 model ChangeOrder {
-  co_id      String   @id @default(uuid())
+  co_id      String             @id @default(uuid())
   project_id String
   title      String?
-  status     ChangeOrderStatus @default(OPEN)
+  status     ChangeOrderStatus  @default(OPEN)
   origin     ChangeOrderOrigin?
   amount     Float?
   created_at DateTime?
@@ -355,7 +371,7 @@ model ChangeOrderPhotoLink {
 }
 
 model ScheduleItem {
-  schedule_id        String   @id @default(uuid())
+  schedule_id        String  @id @default(uuid())
   project_id         String
   week               String
   label              String
@@ -372,13 +388,13 @@ model ScheduleItem {
 }
 
 model Photo {
-  photo_id  String   @id @default(uuid())
+  photo_id   String    @id @default(uuid())
   project_id String
-  taken_at  DateTime?
-  week      String?
-  caption   String?
-  url       String
-  tags      String[]
+  taken_at   DateTime?
+  week       String?
+  caption    String?
+  url        String
+  tags       String[]
   account_id String
 
   @@index([account_id])
@@ -387,12 +403,12 @@ model Photo {
 }
 
 model ExternalLink {
-  link_id    String   @id @default(uuid())
+  link_id    String                 @id @default(uuid())
   project_id String
   label      String
   url        String
   visibility ExternalLinkVisibility @default(PUBLIC)
-  kind       ExternalLinkKind @default(PLANS)
+  kind       ExternalLinkKind       @default(PLANS)
   account_id String
 
   @@index([account_id])
@@ -400,11 +416,11 @@ model ExternalLink {
 }
 
 model Subscription {
-  subscription_id String   @id @default(uuid())
+  subscription_id String                @id @default(uuid())
   project_id      String
   subscriber      String
   events          String[]
-  channel         SubscriptionChannel @default(EMAIL)
+  channel         SubscriptionChannel   @default(EMAIL)
   frequency       SubscriptionFrequency @default(INSTANT)
   account_id      String
 
@@ -413,15 +429,15 @@ model Subscription {
 }
 
 model NotificationEvent {
-  event_id    String   @id @default(uuid())
-  type        String
-  project_id  String
-  entity_type String?
-  entity_id   String?
-  payload     Json?
-  created_at  DateTime?
+  event_id     String    @id @default(uuid())
+  type         String
+  project_id   String
+  entity_type  String?
+  entity_id    String?
+  payload      Json?
+  created_at   DateTime?
   delivered_to String[]
-  account_id  String
+  account_id   String
 
   @@index([account_id])
   @@index([project_id])
@@ -442,32 +458,32 @@ model AuditEvent {
 }
 
 model AccessRequest {
-  access_request_id            String   @id @default(uuid())
-  project_id                   String
-  email_or_phone               String
-  status                       AccessRequestStatus @default(PENDING)
-  requested_at                 DateTime?
+  access_request_id             String              @id @default(uuid())
+  project_id                    String
+  email_or_phone                String
+  status                        AccessRequestStatus @default(PENDING)
+  requested_at                  DateTime?
   decided_by_project_contact_id String?
-  decision_note                String?
-  account_id                   String
+  decision_note                 String?
+  account_id                    String
 
   @@index([account_id])
   @@index([project_id])
 }
 
 model ProjectAccess {
-  project_access_id String   @id @default(uuid())
-  project_id        String
+  project_access_id  String            @id @default(uuid())
+  project_id         String
   project_contact_id String
-  role              ProjectAccessRole @default(VIEWER)
-  account_id        String
+  role               ProjectAccessRole @default(VIEWER)
+  account_id         String
 
   @@index([account_id])
   @@index([project_id])
 }
 
 model ShareLink {
-  sharelink_id String   @id @default(uuid())
+  sharelink_id String         @id @default(uuid())
   project_id   String
   token        String
   scope        ShareLinkScope @default(VIEW)
@@ -478,4 +494,3 @@ model ShareLink {
   @@index([account_id])
   @@index([project_id])
 }
-

--- a/backend/src/routes/authRegister.ts
+++ b/backend/src/routes/authRegister.ts
@@ -1,0 +1,70 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcryptjs';
+import { prisma } from '../db';
+import { HttpError } from '../middleware/errorHandler';
+import { validate } from '../middleware/validate';
+
+const router = Router();
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is not set');
+}
+
+const registerSchema = z.object({
+  account_name: z.string(),
+  email: z.string().email(),
+  password: z.string(),
+});
+
+type RegisterPayload = z.infer<typeof registerSchema>;
+
+router.post(
+  '/',
+  validate(registerSchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { account_name, email, password } = req.body as RegisterPayload;
+    try {
+      const account = await prisma.account.create({ data: { name: account_name } });
+      const password_hash = await bcrypt.hash(password, 10);
+      const user = await prisma.accountUser.create({
+        data: {
+          account_id: account.account_id,
+          email,
+          password_hash,
+        },
+      });
+      const token = jwt.sign(
+        {
+          account_id: account.account_id,
+          account_user_id: user.user_id,
+          project_contact_id: user.project_contact_id,
+          role: 'AccountAdmin',
+          project_roles: {},
+        },
+        JWT_SECRET,
+        { expiresIn: '1h' },
+      );
+      res.cookie('token', token, {
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: 60 * 60 * 1000,
+      });
+      return res.json({
+        session: {
+          account_id: account.account_id,
+          account_user_id: user.user_id,
+          project_contact_id: user.project_contact_id,
+          role: 'AccountAdmin',
+          project_roles: {},
+        },
+      });
+    } catch (err) {
+      return next(new HttpError(500, 'Registration failed'));
+    }
+  },
+);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import authLogin from './authLogin';
 import authLogout from './authLogout';
+import authRegister from './authRegister';
 import accounts from './accounts';
 import projects from './projects';
 import projectOwner from './projectOwner';
@@ -21,6 +22,7 @@ import { projectAccessMiddleware } from '../middleware/projectAccess';
 const router = Router();
 
 router.use('/auth/login', authLogin);
+router.use('/auth/register', authRegister);
 router.use('/auth/logout', authMiddleware(routePermissions['/auth/logout']), authLogout);
 router.use('/accounts', authMiddleware(routePermissions['/accounts']), accounts);
 router.use('/projects', authMiddleware(routePermissions['/projects']), projects);

--- a/backend/tests/authRegister.test.ts
+++ b/backend/tests/authRegister.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+import bcrypt from 'bcryptjs';
+import app from '../src/index';
+
+jest.mock('../src/db', () => ({
+  prisma: {
+    account: { create: jest.fn() },
+    accountUser: { create: jest.fn() },
+  },
+}));
+
+const { prisma } = require('../src/db');
+
+describe('POST /auth/register', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates account and user, returns session token', async () => {
+    (prisma.account.create as jest.Mock).mockResolvedValue({ account_id: 'acc1' });
+    (prisma.accountUser.create as jest.Mock).mockImplementation(async ({ data }: any) => ({
+      user_id: 'user1',
+      account_id: data.account_id,
+      email: data.email,
+      password_hash: data.password_hash,
+      project_contact_id: null,
+    }));
+
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ account_name: 'Acme', email: 'user@example.com', password: 'secret' });
+
+    expect(res.status).toBe(200);
+    expect(prisma.account.create).toHaveBeenCalledWith({ data: { name: 'Acme' } });
+    const createArgs = (prisma.accountUser.create as jest.Mock).mock.calls[0][0];
+    expect(await bcrypt.compare('secret', createArgs.data.password_hash)).toBe(true);
+    expect(res.headers['set-cookie']).toBeDefined();
+    expect(res.body.session).toEqual({
+      account_id: 'acc1',
+      account_user_id: 'user1',
+      project_contact_id: null,
+      role: 'AccountAdmin',
+      project_roles: {},
+    });
+  });
+
+  it('rejects missing fields', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'user@example.com', password: 'secret' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/tests/setupEnv.ts
+++ b/backend/tests/setupEnv.ts
@@ -1,2 +1,3 @@
 process.env.JWT_SECRET = 'test-secret';
+process.env.DATABASE_URL = 'postgresql://localhost:5432/test';
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import Login from '@/pages/Login';
+import Register from '@/pages/Register';
 import ProjectList from '@/pages/ProjectList';
 import ProjectDashboard from '@/pages/ProjectDashboard';
 
@@ -7,6 +8,7 @@ function App() {
   return (
     <Routes>
       <Route path="/" element={<Login />} />
+      <Route path="/register" element={<Register />} />
       <Route path="/projects" element={<ProjectList />} />
       <Route path="/projects/:projectId" element={<ProjectDashboard />} />
     </Routes>

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -3,25 +3,23 @@ import { useNavigate, Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import ResponsiveLayout from '@/components/ResponsiveLayout';
 
-export default function Login() {
+export default function Register() {
+  const [accountName, setAccountName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [projectId, setProjectId] = useState('');
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await fetch('/api/auth/login', {
+      const res = await fetch('/api/auth/register', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, password, project_id: projectId }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ account_name: accountName, email, password }),
         credentials: 'include',
       });
       if (!res.ok) {
-        throw new Error('Login failed');
+        throw new Error('Registration failed');
       }
       await res.json();
       navigate('/projects');
@@ -34,13 +32,22 @@ export default function Login() {
     <ResponsiveLayout>
       <div className="flex min-h-screen items-center justify-center">
         <form className="w-full max-w-sm space-y-4" onSubmit={handleSubmit}>
-          <h1 className="text-center text-2xl font-bold">Login</h1>
+          <h1 className="text-center text-2xl font-bold">Register</h1>
+          <label htmlFor="accountName" className="block">
+            <span className="mb-1 block">Account Name</span>
+            <input
+              id="accountName"
+              type="text"
+              className="w-full rounded border p-2"
+              value={accountName}
+              onChange={(e) => setAccountName(e.target.value)}
+            />
+          </label>
           <label htmlFor="email" className="block">
             <span className="mb-1 block">Email</span>
             <input
               id="email"
               type="email"
-              placeholder="Email"
               className="w-full rounded border p-2"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
@@ -51,28 +58,16 @@ export default function Login() {
             <input
               id="password"
               type="password"
-              placeholder="Password"
               className="w-full rounded border p-2"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
           </label>
-          <label htmlFor="projectId" className="block">
-            <span className="mb-1 block">Project ID</span>
-            <input
-              id="projectId"
-              type="text"
-              placeholder="Project ID"
-              className="w-full rounded border p-2"
-              value={projectId}
-              onChange={(e) => setProjectId(e.target.value)}
-            />
-          </label>
           <Button className="w-full" type="submit">
-            Sign In
+            Create Account
           </Button>
           <p className="text-center text-sm">
-            Need an account? <Link to="/register">Register</Link>
+            Already have an account? <Link to="/">Login</Link>
           </p>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- add AccountUser model and migration linking users to accounts and project contacts
- implement backend POST /auth/register creating accounts and initial users with JWT response
- add frontend registration page and navigation between login and register
- document registration flow in README
- test registration route for password hashing and session token

## Testing
- `pnpm --filter backend test` *(fails: runWorkflow persistence requires a running PostgreSQL instance)*
- `pnpm --filter frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68abb167d57c8325a0ab0a17cd4578b4