### PR TITLE
feat: persist project owner and contacts

### DIFF
--- a/backend/src/routes/projectContacts.ts
+++ b/backend/src/routes/projectContacts.ts
@@ -1,19 +1,44 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { prisma } from '../db';
+import { validate } from '../middleware/validate';
+import { AuthenticatedRequest } from '../middleware/auth';
+import { HttpError } from '../middleware/errorHandler';
 
 const router = Router({ mergeParams: true });
 
-router.post('/', (req: Request, res: Response) => {
-  try {
-    const { project_id } = req.params;
-    const required = ['name', 'email'];
-    const missing = !project_id ? 'project_id' : required.find((f) => !req.body || !req.body[f]);
-    if (missing) {
-      return res.status(400).json({ error: `${missing} required` });
-    }
-    return res.json({});
-  } catch (err) {
-    return res.status(500).json({ error: 'Internal Server Error' });
-  }
+const createContactSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  phone: z.string().optional(),
+  company: z.string().optional(),
+  discipline: z.string().optional(),
+  role: z.string().optional(),
+  visibility: z.string().optional(),
 });
+
+router.post(
+  '/',
+  validate(createContactSchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { project_id } = req.params;
+    const { user } = req as AuthenticatedRequest;
+    if (!project_id) {
+      return next(new HttpError(400, 'project_id required'));
+    }
+    try {
+      const contact = await prisma.projectContact.create({
+        data: {
+          ...req.body,
+          project_id,
+          account_id: user?.account_id,
+        },
+      });
+      return res.json(contact);
+    } catch (err) {
+      return next(new HttpError(500, 'Failed to create project contact'));
+    }
+  },
+);
 
 export default router;

--- a/backend/tests/projectContacts.test.ts
+++ b/backend/tests/projectContacts.test.ts
@@ -1,0 +1,61 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const createMock = jest.fn();
+
+jest.mock('../src/db', () => ({
+  prisma: {
+    projectContact: {
+      create: createMock,
+    },
+  },
+}));
+
+import app from '../src/index';
+
+const token = jwt.sign(
+  { account_id: 'acc', role: 'AccountAdmin', project_contact_id: 'pc1' },
+  'test-secret',
+);
+
+beforeEach(() => {
+  createMock.mockReset();
+});
+
+describe('POST /projects/:project_id/contacts', () => {
+  it('persists contact with account and project scoping', async () => {
+    createMock.mockResolvedValue({
+      project_contact_id: 'pc2',
+      project_id: 'p1',
+      account_id: 'acc',
+      name: 'Bob',
+      email: 'bob@example.com',
+    });
+    const payload = { name: 'Bob', email: 'bob@example.com' };
+    const res = await request(app)
+      .post('/projects/p1/contacts')
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload);
+    expect(res.status).toBe(200);
+    expect(createMock).toHaveBeenCalledWith({
+      data: { ...payload, project_id: 'p1', account_id: 'acc' },
+    });
+    expect(res.body).toEqual({
+      project_contact_id: 'pc2',
+      project_id: 'p1',
+      account_id: 'acc',
+      name: 'Bob',
+      email: 'bob@example.com',
+    });
+  });
+
+  it('returns 400 on invalid payload', async () => {
+    const res = await request(app)
+      .post('/projects/p1/contacts')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Bob' });
+    expect(res.status).toBe(400);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/backend/tests/projectOwner.test.ts
+++ b/backend/tests/projectOwner.test.ts
@@ -1,0 +1,73 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+const upsertMock = jest.fn();
+
+jest.mock('../src/db', () => ({
+  prisma: {
+    projectAccess: {
+      upsert: upsertMock,
+    },
+  },
+}));
+
+import app from '../src/index';
+
+const token = jwt.sign(
+  { account_id: 'acc', role: 'AccountAdmin', project_contact_id: 'pc1' },
+  'test-secret',
+);
+
+beforeEach(() => {
+  upsertMock.mockReset();
+});
+
+describe('POST /projects/:project_id/owner', () => {
+  it('assigns project owner and scopes by account', async () => {
+    upsertMock.mockResolvedValue({
+      project_access_id: 'p1',
+      project_id: 'p1',
+      project_contact_id: 'pc2',
+      role: 'ProjectOwner',
+      account_id: 'acc',
+    });
+    const res = await request(app)
+      .post('/projects/p1/owner')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ project_contact_id: 'pc2' });
+    expect(res.status).toBe(200);
+    expect(upsertMock).toHaveBeenCalledWith({
+      where: { project_access_id: 'p1' },
+      update: {
+        project_contact_id: 'pc2',
+        role: 'ProjectOwner',
+        account_id: 'acc',
+        project_id: 'p1',
+      },
+      create: {
+        project_access_id: 'p1',
+        project_id: 'p1',
+        project_contact_id: 'pc2',
+        role: 'ProjectOwner',
+        account_id: 'acc',
+      },
+    });
+    expect(res.body).toEqual({
+      project_access_id: 'p1',
+      project_id: 'p1',
+      project_contact_id: 'pc2',
+      role: 'ProjectOwner',
+      account_id: 'acc',
+    });
+  });
+
+  it('returns 400 when project_contact_id missing', async () => {
+    const res = await request(app)
+      .post('/projects/p1/owner')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- save project owner assignment via projectAccess upsert
- persist project contacts scoped to account and project
- add tests for project owner and contact routes

## Testing
- `pnpm --filter backend test` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*


------
https://chatgpt.com/codex/tasks/task_e_68abad1560308325a74544aed46e1e42