### PR TITLE
feat: add backend server entry with configurable port

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ pnpm dev
 
 The `pnpm dev` script launches the backend API and the frontend client concurrently.
 
+The backend server listens on port `3000` by default. Set the `PORT` environment variable to override this value.
+
 ## User Registration
 
 New accounts are created through the registration endpoint. Send a `POST` request to `/auth/register` with:

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "cross-env JWT_SECRET=dev-secret ts-node src/index.ts",
+    "dev": "cross-env JWT_SECRET=dev-secret ts-node src/server.ts",
     "build": "tsc",
-    "start": "cross-env JWT_SECRET=dev-secret node dist/index.js",
+    "start": "cross-env JWT_SECRET=dev-secret node dist/server.js",
     "db:migrate": "prisma migrate deploy",
     "db:seed": "prisma db seed",
     "test": "cross-env JWT_SECRET=test-secret jest",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,7 @@
+import app from './index';
+
+const port = process.env.PORT ?? 3000;
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add server.ts entry point that listens on configurable PORT (default 3000)
- route backend scripts through new server entry
- document default backend port

## Testing
- `cd backend && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68abba5e8a848325b82e149a988a65a1