### PR TITLE
chore: add api base path

### DIFF
--- a/CrewdexSchema.yaml
+++ b/CrewdexSchema.yaml
@@ -319,7 +319,7 @@ routes:
   # Auth
   - name: login
     method: POST
-    path: /auth/login
+    path: /api/auth/login
     input:
       email: string
       project_id: string
@@ -332,7 +332,7 @@ routes:
 
   - name: logout
     method: POST
-    path: /auth/logout
+    path: /api/auth/logout
     input: {}
     output: { ok: boolean }
     permissions: authenticated
@@ -340,7 +340,7 @@ routes:
   # Projects
   - name: create_project
     method: POST
-    path: /projects
+    path: /api/projects
     input:
       name: string
       client: string
@@ -352,7 +352,7 @@ routes:
 
   - name: assign_project_owner
     method: POST
-    path: /projects/{project_id}/owner
+    path: /api/projects/{project_id}/owner
     input:
       project_contact_id: string
     output: ProjectAccess
@@ -360,7 +360,7 @@ routes:
 
   - name: list_projects
     method: GET
-    path: /projects
+    path: /api/projects
     input: {}
     output: [Project]
     permissions: authenticated
@@ -368,7 +368,7 @@ routes:
   # Contacts & Scopes
   - name: create_project_contact
     method: POST
-    path: /projects/{project_id}/contacts
+    path: /api/projects/{project_id}/contacts
     input:
       name: string
       email: string
@@ -382,7 +382,7 @@ routes:
 
   - name: link_contact_scope
     method: POST
-    path: /projects/{project_id}/contacts/{project_contact_id}/scopes
+    path: /api/projects/{project_id}/contacts/{project_contact_id}/scopes
     input:
       scopecode: string
       activity_labels: [string]
@@ -392,7 +392,7 @@ routes:
 
   - name: list_contact_scopes
     method: GET
-    path: /projects/{project_id}/contacts/{project_contact_id}/scopes
+    path: /api/projects/{project_id}/contacts/{project_contact_id}/scopes
     input: {}
     output: [ProjectContactScopeLink]
     permissions: authenticated
@@ -400,7 +400,7 @@ routes:
   # Flags & Photos
   - name: create_flag
     method: POST
-    path: /projects/{project_id}/flags
+    path: /api/projects/{project_id}/flags
     input:
       kind: string
       date: string            # Today | Enter Date
@@ -413,7 +413,7 @@ routes:
 
   - name: upload_photo
     method: POST
-    path: /projects/{project_id}/photos
+    path: /api/projects/{project_id}/photos
     input:
       file_ref: string        # storage key
       taken_at: datetime?
@@ -425,7 +425,7 @@ routes:
 
   - name: attach_photo_to_flag
     method: POST
-    path: /projects/{project_id}/flags/{flag_id}/photos
+    path: /api/projects/{project_id}/flags/{flag_id}/photos
     input:
       photo_id: string
     output: FlagPhotoLink
@@ -434,7 +434,7 @@ routes:
   # Reports
   - name: create_report_template
     method: POST
-    path: /projects/{project_id}/report-templates
+    path: /api/projects/{project_id}/report-templates
     input:
       name: string
       filter:
@@ -449,7 +449,7 @@ routes:
 
   - name: generate_report_from_template
     method: POST
-    path: /projects/{project_id}/report-templates/{template_id}/generate
+    path: /api/projects/{project_id}/report-templates/{template_id}/generate
     input:
       week: string?
       title: string?
@@ -459,7 +459,7 @@ routes:
   # Schedule quick-pick (pcsl + activity)
   - name: create_schedule_item
     method: POST
-    path: /projects/{project_id}/schedule
+    path: /api/projects/{project_id}/schedule
     input:
       week: string
       pcsl_id: string
@@ -471,7 +471,7 @@ routes:
 
   - name: list_schedule_by_week
     method: GET
-    path: /projects/{project_id}/schedule
+    path: /api/projects/{project_id}/schedule
     input:
       week: string
     output: [ScheduleItem]
@@ -480,7 +480,7 @@ routes:
   # Notifications
   - name: subscribe
     method: POST
-    path: /projects/{project_id}/subscriptions
+    path: /api/projects/{project_id}/subscriptions
     input:
       subscriber: string
       events: [string]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The `pnpm dev` script launches the backend API and the frontend client concurren
 
 ## User Registration
 
-New accounts are created through the registration endpoint. Send a `POST` request to `/auth/register` with:
+New accounts are created through the registration endpoint. Send a `POST` request to `/api/auth/register` with:
 
 ```json
 {
@@ -35,7 +35,7 @@ Users authenticate with email and password against an account-wide user table. P
 - `user_id`
 - `project_roles` – mapping of project IDs to the user's role
 
-The login request must include the following JSON body:
+Send a `POST` request to `/api/auth/login` with the following JSON body:
 
 ```json
 {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,8 +10,8 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
-// Mount application routes
-app.use('/', routes);
+// Mount application routes under a consistent API prefix
+app.use('/api', routes);
 
 // Centralized error handler ensures consistent error responses
 app.use(errorHandler);

--- a/backend/tests/authLogin.test.ts
+++ b/backend/tests/authLogin.test.ts
@@ -12,7 +12,7 @@ jest.mock('../src/db', () => ({
 
 const { prisma } = require('../src/db');
 
-describe('POST /auth/login', () => {
+describe('POST /api/auth/login', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -33,7 +33,7 @@ describe('POST /auth/login', () => {
     ]);
 
     const res = await request(app)
-      .post('/auth/login')
+      .post('/api/auth/login')
       .send({ email: 'user@example.com', password });
 
     expect(res.status).toBe(200);
@@ -54,7 +54,7 @@ describe('POST /auth/login', () => {
       password_hash: hash,
     });
     const res = await request(app)
-      .post('/auth/login')
+      .post('/api/auth/login')
       .send({ email: 'user@example.com', password: 'wrong' });
     expect(res.status).toBe(401);
   });
@@ -62,21 +62,21 @@ describe('POST /auth/login', () => {
   it('rejects unknown user', async () => {
     (prisma.accountUser.findUnique as jest.Mock).mockResolvedValue(null);
     const res = await request(app)
-      .post('/auth/login')
+      .post('/api/auth/login')
       .send({ email: 'user@example.com', password: 'secret' });
     expect(res.status).toBe(401);
   });
 
   it('rejects missing fields', async () => {
     const res = await request(app)
-      .post('/auth/login')
+      .post('/api/auth/login')
       .send({ email: 'user@example.com' });
     expect(res.status).toBe(400);
   });
 
   it('rejects invalid email format', async () => {
     const res = await request(app)
-      .post('/auth/login')
+      .post('/api/auth/login')
       .send({ email: 'not-an-email', password: 'secret' });
     expect(res.status).toBe(400);
   });

--- a/backend/tests/authRegister.test.ts
+++ b/backend/tests/authRegister.test.ts
@@ -12,7 +12,7 @@ jest.mock('../src/db', () => ({
 
 const { prisma } = require('../src/db');
 
-describe('POST /auth/register', () => {
+describe('POST /api/auth/register', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -28,7 +28,7 @@ describe('POST /auth/register', () => {
     }));
 
     const res = await request(app)
-      .post('/auth/register')
+      .post('/api/auth/register')
       .send({ account_name: 'Acme', email: 'user@example.com', password: 'secret' });
 
     expect(res.status).toBe(200);
@@ -47,7 +47,7 @@ describe('POST /auth/register', () => {
 
   it('rejects missing fields', async () => {
     const res = await request(app)
-      .post('/auth/register')
+      .post('/api/auth/register')
       .send({ email: 'user@example.com', password: 'secret' });
     expect(res.status).toBe(400);
   });
@@ -62,7 +62,7 @@ describe('POST /auth/register', () => {
     );
 
     const res = await request(app)
-      .post('/auth/register')
+      .post('/api/auth/register')
       .send({ account_name: 'Acme', email: 'user@example.com', password: 'secret' });
 
     expect(res.status).toBe(409);

--- a/backend/tests/projectContacts.test.ts
+++ b/backend/tests/projectContacts.test.ts
@@ -27,7 +27,7 @@ beforeEach(() => {
   createMock.mockReset();
 });
 
-describe('POST /projects/:project_id/contacts', () => {
+describe('POST /api/projects/:project_id/contacts', () => {
   it('persists contact with account and project scoping', async () => {
     createMock.mockResolvedValue({
       project_contact_id: 'pc2',
@@ -38,7 +38,7 @@ describe('POST /projects/:project_id/contacts', () => {
     });
     const payload = { name: 'Bob', email: 'bob@example.com' };
     const res = await request(app)
-      .post('/projects/p1/contacts')
+      .post('/api/projects/p1/contacts')
       .set('Authorization', `Bearer ${token}`)
       .send(payload);
     expect(res.status).toBe(200);
@@ -56,7 +56,7 @@ describe('POST /projects/:project_id/contacts', () => {
 
   it('returns 400 on invalid payload', async () => {
     const res = await request(app)
-      .post('/projects/p1/contacts')
+      .post('/api/projects/p1/contacts')
       .set('Authorization', `Bearer ${token}`)
       .send({ name: 'Bob' });
     expect(res.status).toBe(400);

--- a/backend/tests/projectOwner.test.ts
+++ b/backend/tests/projectOwner.test.ts
@@ -27,7 +27,7 @@ beforeEach(() => {
   upsertMock.mockReset();
 });
 
-describe('POST /projects/:project_id/owner', () => {
+describe('POST /api/projects/:project_id/owner', () => {
   it('assigns project owner and scopes by account', async () => {
     upsertMock.mockResolvedValue({
       project_access_id: 'p1',
@@ -37,7 +37,7 @@ describe('POST /projects/:project_id/owner', () => {
       account_id: 'acc',
     });
     const res = await request(app)
-      .post('/projects/p1/owner')
+      .post('/api/projects/p1/owner')
       .set('Authorization', `Bearer ${token}`)
       .send({ project_contact_id: 'pc2' });
     expect(res.status).toBe(200);
@@ -68,7 +68,7 @@ describe('POST /projects/:project_id/owner', () => {
 
   it('returns 400 when project_contact_id missing', async () => {
     const res = await request(app)
-      .post('/projects/p1/owner')
+      .post('/api/projects/p1/owner')
       .set('Authorization', `Bearer ${token}`)
       .send({});
     expect(res.status).toBe(400);

--- a/backend/tests/projects.test.ts
+++ b/backend/tests/projects.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
   findManyMock.mockReset();
 });
 
-describe('POST /projects', () => {
+describe('POST /api/projects', () => {
   it('persists account_id for tenant isolation', async () => {
     createMock.mockResolvedValue({ project_id: 'p1', account_id: 'acc' });
     const payload = {
@@ -32,7 +32,7 @@ describe('POST /projects', () => {
       creator_email: 'alice@example.com',
     };
     const res = await request(app)
-      .post('/projects')
+      .post('/api/projects')
       .set('Authorization', `Bearer ${token}`)
       .send(payload);
     expect(res.status).toBe(200);
@@ -43,7 +43,7 @@ describe('POST /projects', () => {
 
   it('returns 400 on invalid payload', async () => {
     const res = await request(app)
-      .post('/projects')
+      .post('/api/projects')
       .set('Authorization', `Bearer ${token}`)
       .send({
         name: 'Project',
@@ -55,13 +55,13 @@ describe('POST /projects', () => {
   });
 });
 
-describe('GET /projects', () => {
+describe('GET /api/projects', () => {
   it('filters projects by account_id', async () => {
     findManyMock.mockResolvedValue([
       { project_id: 'p1', name: 'Proj', account_id: 'acc' },
     ]);
     const res = await request(app)
-      .get('/projects')
+      .get('/api/projects')
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(findManyMock).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- mount Express router under `/api`
- document and test new `/api` prefix

## Testing
- `pnpm --filter backend test`
- `pnpm --filter frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68abba63eab08325b40710d4c132c384