### PR TITLE
Clarify auth endpoints and proxy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ pnpm install
 pnpm dev
 ```
 
-The `pnpm dev` script launches the backend API and the frontend client concurrently.
+The `pnpm dev` script launches the backend API and the frontend client concurrently. The backend requires a
+`JWT_SECRET` environment variable, which the script sets to `dev-secret` for convenience. If the frontend runs on a
+different port, configure your dev server to proxy API requests (e.g. `/auth/*` and `/projects`) to the backend
+(`http://localhost:3000`).
 
 ## User Registration
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -13,7 +13,7 @@ export default function Login() {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch('/api/auth/login', {
+        const res = await fetch('/auth/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/pages/Login.test.jsx
+++ b/frontend/src/pages/Login.test.jsx
@@ -28,8 +28,8 @@ test('redirects to project dashboard when only one project is returned', async (
   await userEvent.type(screen.getByLabelText(/Email/i), 'a@b.com');
   await userEvent.type(screen.getByLabelText(/Password/i), 'secret');
   await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
-  expect(fetch).toHaveBeenCalledWith(
-    '/api/auth/login',
+    expect(fetch).toHaveBeenCalledWith(
+      '/auth/login',
     expect.objectContaining({
       method: 'POST',
       body: JSON.stringify({ email: 'a@b.com', password: 'secret' }),

--- a/frontend/src/pages/ProjectList.jsx
+++ b/frontend/src/pages/ProjectList.jsx
@@ -11,7 +11,7 @@ export default function ProjectList() {
   } = useQuery({
     queryKey: ['projects'],
     queryFn: async () => {
-      const res = await fetch('/api/projects');
+        const res = await fetch('/projects');
       if (!res.ok) throw new Error('Failed to load projects');
       return res.json();
     },

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -16,7 +16,7 @@ export default function Register() {
     setError('');
     setSuccess('');
     try {
-      const res = await fetch('/api/auth/register', {
+        const res = await fetch('/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ account_name: accountName, email, password }),

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -38,7 +38,8 @@ export default defineConfig({
             },
           },
           {
-            urlPattern: /\/api\//,
+            urlPattern: ({ url }) =>
+              url.pathname.startsWith('/auth') || url.pathname.startsWith('/projects'),
             handler: 'NetworkFirst',
             options: { cacheName: 'api-cache' },
           },


### PR DESCRIPTION
## Summary
- document that registration lives at `/auth/register`
- note required `JWT_SECRET` and need for proxying API calls in dev
- align frontend API calls and service-worker caching with `/auth` and `/projects`

## Testing
- `pnpm --filter backend test`
- `pnpm --filter frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68abba4b6968832590b92663125e4249