### PR TITLE
Proxy API auth endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pnpm dev
 
 The `pnpm dev` script launches the backend API and the frontend client concurrently. The backend requires a
 `JWT_SECRET` environment variable, which the script sets to `dev-secret` for convenience. If the frontend runs on a
-different port, configure your dev server to proxy API requests (e.g. `/auth/*` and `/projects`) to the backend
+different port, configure your dev server to proxy API requests (e.g. `/api/auth/*` and `/projects`) to the backend
 (`http://localhost:3000`).
 
 The backend server listens on port `3000` by default. Set the `PORT` environment variable to override this value.

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -13,7 +13,7 @@ export default function Login() {
     e.preventDefault();
     setError('');
     try {
-        const res = await fetch('/auth/login', {
+        const res = await fetch('/api/auth/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/pages/Login.test.jsx
+++ b/frontend/src/pages/Login.test.jsx
@@ -29,12 +29,12 @@ test('redirects to project dashboard when only one project is returned', async (
   await userEvent.type(screen.getByLabelText(/Password/i), 'secret');
   await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
     expect(fetch).toHaveBeenCalledWith(
-      '/auth/login',
-    expect.objectContaining({
-      method: 'POST',
-      body: JSON.stringify({ email: 'a@b.com', password: 'secret' }),
-    }),
-  );
+      '/api/auth/login',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ email: 'a@b.com', password: 'secret' }),
+      }),
+    );
   await waitFor(() =>
     expect(mockNavigate).toHaveBeenCalledWith('/projects/p1'),
   );

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -16,7 +16,7 @@ export default function Register() {
     setError('');
     setSuccess('');
     try {
-        const res = await fetch('/auth/register', {
+        const res = await fetch('/api/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ account_name: accountName, email, password }),

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,6 +9,9 @@ const manifest = JSON.parse(
 );
 
 export default defineConfig({
+  server: {
+    proxy: { '/api': { target: 'http://localhost:3000', changeOrigin: true } },
+  },
   plugins: [
     react(),
     VitePWA({
@@ -39,7 +42,7 @@ export default defineConfig({
           },
           {
             urlPattern: ({ url }) =>
-              url.pathname.startsWith('/auth') || url.pathname.startsWith('/projects'),
+              url.pathname.startsWith('/api/auth') || url.pathname.startsWith('/projects'),
             handler: 'NetworkFirst',
             options: { cacheName: 'api-cache' },
           },


### PR DESCRIPTION
## Summary
- route frontend auth requests through `/api` proxy
- support new auth path in login tests
- add dev server proxy and adjust service worker caching to `/api/auth`

## Testing
- `pnpm lint` *(fails: 'beforeEach' is not defined no-undef)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abbd16abe883259d7a5ff4b596fad7