### PR TITLE
Handle JSON error responses on register

### DIFF
--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -23,15 +23,20 @@ export default function Register() {
         credentials: 'include',
       });
       if (!res.ok) {
-        const message = await res.text();
-        setError(message || 'Registration failed');
+        let data;
+        try {
+          data = await res.json();
+        } catch {
+          // ignore JSON parsing errors
+        }
+        setError(data?.error?.message || 'Registration failed');
         return;
       }
       await res.json();
       setSuccess('Registration successful. Redirecting to login...');
       setTimeout(() => navigate('/'), 1500);
     } catch (err) {
-      setError(err.message || 'Registration failed');
+      setError(err?.message || 'Registration failed');
       console.error(err);
     }
   };


### PR DESCRIPTION
## Summary
- handle non-ok registration responses by parsing JSON error payloads
- fall back to a generic message when the response or error shape is unexpected

## Testing
- `pnpm --filter frontend lint` *(fails: jest globals not defined)*
- `pnpm --filter frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68abbfc34eb88325b1677b0904f7b1a5