### PR TITLE
Log registration errors and handle Prisma init failure

### DIFF
--- a/backend/src/routes/authRegister.ts
+++ b/backend/src/routes/authRegister.ts
@@ -63,6 +63,10 @@ router.post(
         },
       });
     } catch (err) {
+      console.error(err);
+      if (err instanceof Prisma.PrismaClientInitializationError) {
+        return next(new HttpError(503, 'Database unavailable'));
+      }
       if (
         err instanceof Prisma.PrismaClientKnownRequestError &&
         err.code === 'P2002'


### PR DESCRIPTION
## Summary
- log original errors before wrapping in HttpError
- return 503 "Database unavailable" when Prisma client fails to initialize

## Testing
- `pnpm --filter backend test`


------
https://chatgpt.com/codex/tasks/task_e_68abbfc2081883258e7cf39b86bdcd00