### PR TITLE
feat: load database url from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env
+!backend/.env
 backend/dist/

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://user:pass@host:5432/dbname"

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "@prisma/client": "^6.14.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",
+    "dotenv": "^17.2.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
     "prisma": "^6.14.0",
@@ -32,11 +33,11 @@
     "@types/jest": "^29.5.11",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/supertest": "^2.0.12",
+    "cross-env": "^7.0.3",
     "jest": "^29.7.0",
     "supertest": "^6.3.4",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2",
-    "cross-env": "^7.0.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import app from './index';
 
 const port = process.env.PORT ?? 3000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       cookie-parser:
         specifier: ^1.4.7
         version: 1.4.7
+      dotenv:
+        specifier: ^17.2.1
+        version: 17.2.1
       express:
         specifier: ^4.18.2
         version: 4.21.2
@@ -2256,6 +2259,10 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.2.1:
+    resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -6701,6 +6708,8 @@ snapshots:
       webidl-conversions: 7.0.0
 
   dotenv@16.6.1: {}
+
+  dotenv@17.2.1: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add DATABASE_URL to backend .env and commit file
- load environment variables in server via dotenv
- allow backend .env through gitignore

## Testing
- `pnpm --filter backend test`
- `pnpm --filter backend dev` (server starts)


------
https://chatgpt.com/codex/tasks/task_e_68abc157cc908325a76877adc4131791